### PR TITLE
Fix applyPluginsAsyncWaterfall to use local plugin order

### DIFF
--- a/lib/Tapable.js
+++ b/lib/Tapable.js
@@ -76,16 +76,14 @@ Tapable.prototype.applyPluginsAsyncSeries = Tapable.prototype.applyPluginsAsync 
 Tapable.prototype.applyPluginsAsyncWaterfall = function applyPluginsAsyncWaterfall(name, init, callback) {
 	if(!this._plugins[name] || this._plugins[name].length == 0) return callback(null, init);
 	var plugins = this._plugins[name];
-	var old = this._currentPluginApply;
-	this._currentPluginApply = 0;
+	var _currentPluginApply = 0;
 	var next = copyProperties(callback, function(err, value) {
 		if(err) return callback(err);
-		this._currentPluginApply++;
-		if(this._currentPluginApply >= plugins.length) {
-			this._currentPluginApply = old;
+		_currentPluginApply++;
+		if(_currentPluginApply >= plugins.length) {
 			return callback(null, value);
 		}
-		plugins[this._currentPluginApply].call(this, value, next);
+		plugins[_currentPluginApply].call(this, value, next);
 	}.bind(this));
 	plugins[0].call(this, init, next);
 };


### PR DESCRIPTION
This prevents race conditions when user code calls a function multiple times
without waiting for plugin pipeline to complete. See case described in
webpack/webpack#243.