### PR TITLE
create applyPluginsWaterfallWhileCond method

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Synchronous applies all registered handers for `name`. The handler functions are
 any applyPluginsWaterfallWhileCond(name: string, init: any, cond: function, args: any...)
 ```
 
-Synchronous applies all registered handers for `name`. The handler functions are called with the return value of the previous handler and all args. For the first handler `init` is used.  `cond` will be called with `init`/return value of the previous handler before the first/next handler is called; if it returns falsey, no more handlers will be applied and the current value will be returned.  Otherwise the return value of the very last handler will be returned.  This can be used to create plugins that filter the application of other plugins.
+Synchronous applies all registered handers for `name`. The handler functions are called with the return value of the previous handler and all args. For the first handler `init` is used.  `cond` will be called with `init`/return value of the previous handler before the first/next handler is called; if it returns falsey, no more handlers will be applied and the current value will be returned.  Otherwise the return value of the very last handler will be returned.  This can be used to create plugins that filter the application of other plugins.  `cond` defaults to the identity function (but must be provided if any additonal args are to be given).
 
 ### applyPluginsAsync
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ any applyPluginsWaterfall(name: string, init: any, args: any...)
 
 Synchronous applies all registered handers for `name`. The handler functions are called with the return value of the previous handler and all args. For the first handler `init` is used and the return value of the last handler is return by `applyPluginsWaterfall`
 
+### applyPluginsWaterfallWhileCond
+
+``` javascript
+any applyPluginsWaterfallWhileCond(name: string, init: any, cond: function, args: any...)
+```
+
+Synchronous applies all registered handers for `name`. The handler functions are called with the return value of the previous handler and all args. For the first handler `init` is used.  `cond` will be called with `init`/return value of the previous handler before the first/next handler is called; if it returns falsey, no more handlers will be applied and the current value will be returned.  Otherwise the return value of the very last handler will be returned.  This can be used to create plugins that filter the application of other plugins.
+
 ### applyPluginsAsync
 
 ``` javascript

--- a/lib/Tapable.js
+++ b/lib/Tapable.js
@@ -42,6 +42,7 @@ Tapable.prototype.applyPluginsWaterfall = function applyPlugins(name, init) {
 Tapable.prototype.applyPluginsWaterfallWhileCond = function applyPlugins(name, init, cond) {
 	if(!this._plugins[name]) return init;
 	var args = Array.prototype.slice.call(arguments, 3);
+	if (!cond) cond = function(i) { return i; };
 	var plugins = this._plugins[name];
 	var current = init;
 	var old = this._currentPluginApply;

--- a/lib/Tapable.js
+++ b/lib/Tapable.js
@@ -39,6 +39,18 @@ Tapable.prototype.applyPluginsWaterfall = function applyPlugins(name, init) {
 	return current;
 };
 
+Tapable.prototype.applyPluginsWaterfallWhileCond = function applyPlugins(name, init, cond) {
+	if(!this._plugins[name]) return init;
+	var args = Array.prototype.slice.call(arguments, 3);
+	var plugins = this._plugins[name];
+	var current = init;
+	var old = this._currentPluginApply;
+	for(this._currentPluginApply = 0; cond(current) && this._currentPluginApply < plugins.length; this._currentPluginApply++)
+		current = plugins[this._currentPluginApply].apply(this, [current].concat(args));
+	this._currentPluginApply = old;
+	return current;
+};
+
 Tapable.prototype.applyPluginsBailResult = function applyPluginsBailResult(name) {
 	if(!this._plugins[name]) return;
 	var args = Array.prototype.slice.call(arguments, 1);


### PR DESCRIPTION
I created this so that I could make plugins that act as filters for what subsequent plugins are applied.  This method is like applyPluginsWaterfall but bails when the given condition function returns falsey when called with the current value.  For instance if the condition just returns the current value, a plugin that returns `undefined` instead of the current value under certain circumstances would prevent application of subsequent plugins.