### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "engines": {
     "node": ">=0.6"
   },
+  "files": ["lib"],
   "homepage": "https://github.com/webpack/tapable",
   "main": "lib/Tapable.js",
   "scripts": {


### PR DESCRIPTION
Prevents tests and dotfiles from being published to NPM.