### PR TITLE
Use a pre-ES5 version of Array filtering to avoid expensive defineProperty call

### DIFF
--- a/lib/Tapable.js
+++ b/lib/Tapable.js
@@ -2,6 +2,42 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+
+// polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
+// using the polyfill specifically to avoid the call to `Object.defineProperty` for performance reasons
+function fastFilter(fun/*, thisArg*/) {
+	'use strict';
+
+	if (this === void 0 || this === null) {
+		throw new TypeError();
+	}
+
+	var t = Object(this);
+	var len = t.length >>> 0;
+	if (typeof fun !== 'function') {
+		throw new TypeError();
+	}
+
+	var res = [];
+	var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+	for (var i = 0; i < len; i++) {
+		if (i in t) {
+			var val = t[i];
+
+			// NOTE: Technically this should Object.defineProperty at
+			//       the next index, as push can be affected by
+			//       properties on Object.prototype and Array.prototype.
+			//       But that method's new, and collisions should be
+			//       rare, so use the more-compatible alternative.
+			if (fun.call(thisArg, val, i, t)) {
+				res.push(val);
+			}
+		}
+	}
+
+	return res;
+}
+
 function Tapable() {
 	this._plugins = {};
 }
@@ -210,7 +246,7 @@ Tapable.prototype.applyPluginsParallelBailResult = function applyPluginsParallel
 				done.push(i);
 				if(arguments.length > 0) {
 					currentPos = i + 1;
-					done = done.filter(function(item) {
+					done = fastFilter.call(done, function(item) {
 						return item <= i;
 					});
 					currentResult = Array.prototype.slice.call(arguments);
@@ -238,7 +274,7 @@ Tapable.prototype.applyPluginsParallelBailResult1 = function applyPluginsParalle
 				done.push(i);
 				if(arguments.length > 0) {
 					currentPos = i + 1;
-					done = done.filter(function(item) {
+					done = fastFilter.call(done, function(item) {
 						return item <= i;
 					});
 					currentResult = Array.prototype.slice.call(arguments);


### PR DESCRIPTION
While profiling our Webpack build I noticed roughly 11% of execution time comes from `Array.prototype.filter`'s call to `defineProperty`, almost all of that filtering comes from `applyPluginsParallelBailResult1`. Calling MDN's `filter` polyfill instead removes that overhead.

Results:

without change:
```303108ms
real	5m5.751s
user	5m4.721s
sys	0m4.788s
```

calling `fastFilter`:
```280671ms
real	4m43.964s
user	4m42.328s
sys	0m4.669s
```