### PR TITLE
Macro optimisation of copyProperties.

### DIFF
--- a/lib/Tapable.js
+++ b/lib/Tapable.js
@@ -44,8 +44,12 @@ function Tapable() {
 module.exports = Tapable;
 
 function copyProperties(from, to) {
-	for(var key in from)
+	var keys = Object.keys(from);
+	var key;
+	for (var i = 0; i < keys.length; i++) {
+		key = keys[i];
 		to[key] = from[key];
+	}
 	return to;
 }
 


### PR DESCRIPTION
According to  https://jsperf.com/object-keys-vs-for-in-with-closure/3 .