### PR TITLE
DRY up tappable code for applyPlugins.

### DIFF
--- a/lib/Tapable.js
+++ b/lib/Tapable.js
@@ -53,33 +53,46 @@ Tapable.mixin = function mixinTapable(pt) {
 	copyProperties(Tapable.prototype, pt);
 };
 
-Tapable.prototype.applyPlugins = function applyPlugins(name) {
+Tapable.prototype.applyPlugins = function applyPlugins(name, param1, param2) {
 	if(!this._plugins[name]) return;
-	var args = Array.prototype.slice.call(arguments, 1);
+
 	var plugins = this._plugins[name];
-	for(var i = 0; i < plugins.length; i++)
-		plugins[i].apply(this, args);
-};
+
+	switch (arguments.length) {
+		case 1: 
+			for(var i = 0; i < plugins.length; i++) {
+				plugins[i].call(this);
+			}
+			break;
+		case 2:
+			for(var i = 0; i < plugins.length; i++) {
+				plugins[i].call(this, param1);
+			}
+			break;
+		case 3:
+			for(var i = 0; i < plugins.length; i++) {
+				plugins[i].call(this, param1, param2);
+			}
+			break;
+		default:
+			var args = array.prototype.slice.call(arguments, 1);
+			for(var i = 0; i < plugins.length; i++) {
+				plugins[i].apply(this, args);
+			}
+			break;
+	}
+}
 
 Tapable.prototype.applyPlugins0 = function applyPlugins0(name) {
-	var plugins = this._plugins[name];
-	if(!plugins) return;
-	for(var i = 0; i < plugins.length; i++)
-		plugins[i].call(this);
+	this.applyPlugins(name)
 };
 
 Tapable.prototype.applyPlugins1 = function applyPlugins1(name, param) {
-	var plugins = this._plugins[name];
-	if(!plugins) return;
-	for(var i = 0; i < plugins.length; i++)
-		plugins[i].call(this, param);
+	this.applyPlugins(name, param)
 };
 
 Tapable.prototype.applyPlugins2 = function applyPlugins2(name, param1, param2) {
-	var plugins = this._plugins[name];
-	if(!plugins) return;
-	for(var i = 0; i < plugins.length; i++)
-		plugins[i].call(this, param1, param2);
+	this.applyPlugins(name, param1, param2)
 };
 
 Tapable.prototype.applyPluginsWaterfall = function applyPluginsWaterfall(name, init) {


### PR DESCRIPTION
migrate the logic to live in the root function and use a switch
statement to decide when to use call / apply.

Keep the existing functions in place and call though to maintain
backwards compat.

original ref bug:
https://github.com/webpack/tapable/issues/33

---

If you are OK with this change we can delete most of the code in this repo for all of the other functions.