### PR TITLE
Add typings for tapable

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-beta.1",
   "author": "Tobias Koppers @sokra",
   "description": "Just a little module for plugins.",
+  "typings": "types/index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,7 +15,8 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "codecov": "^2.3.0",
-    "jest": "^21.0.4"
+    "jest": "^21.0.4",
+    "typescript": "^2.6.1"
   },
   "engines": {
     "node": ">=4.3"
@@ -26,7 +28,8 @@
   "main": "lib/Tapable.js",
   "scripts": {
     "test": "jest",
-    "travis": "jest --coverage && codecov"
+    "travis": "jest --coverage && codecov",
+    "test:types": "tsc -p types/test"
   },
   "jest": {
     "transform": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,63 +1,62 @@
-declare module "tapable" {
-	/**
-	 * @deprecated
-	 */
-	export abstract class Tapable {
-		static addCompatLayer<T>(instance: T): T & Tapable;
+/**
+ * @deprecated
+ */
+export abstract class Tapable {
+	static addCompatLayer<T>(instance: T): T & Tapable;
 
-		abstract hooks: Record<string, Hook<any, any, any, any, any, any, any, any>>;
-		protected _pluginCompat: SyncBailHook<CompatOption>;
-		apply(...tapables: Plugin[]): void;
-		plugin(name: string, fn: Function): void;
-	}
+	abstract hooks: Record<string, Hook<any, any, any, any, any, any, any, any>>;
+	protected _pluginCompat: SyncBailHook<CompatOption>;
+	apply(...tapables: Plugin[]): void;
+	plugin(name: string, fn: Function): void;
+}
 
-	type Fn<A, B, C, D, E, F, G, H> = (a?: A, b?: B, c?: C, d?: D, e?: E, f?: F, g?: G, h?: H, ...args: any[]) => any;
+type FnCall<A, B, C, D, E, F, G, H> = (a?: A, b?: B, c?: C, d?: D, e?: E, f?: F, g?: G, h?: H, ...args: any[]) => any;
+type FnUse<A, B, C, D, E, F, G, H> = (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, ...args: any[]) => any;
 
-	class Hook<A, B, C, D, E, F, G, H> {
-		call: Fn<A, B, C, D, E, F, G, H>;
-		tap(name: string, fn: Fn<A, B, C, D, E, F, G, H>): void;
-		tap(option: Option, fn: Fn<A, B, C, D, E, F, G, H>): void;
-		withOptions(options: object): this;
-		isUsed(): boolean;
-		intercept(interceptor: Interceptor): void;
-	}
-	class AsyncHook<A, B, C, D, E, F, G, H> extends Hook<A, B, C, D, E, F, G, H> {
-		callAsync: Fn<A, B, C, D, E, F, G, H>;
-		promise: (a?: A, b?: B, c?: C, d?: D, e?: E, f?: F, g?: G, h?: H, ...args: any[]) => Promise<any>;
-		tapAsync(name: string, fn: Fn<A, B, C, D, E, F, G, H>): void;
-		tapAsync(option: object, fn: Fn<A, B, C, D, E, F, G, H>): void;
-		tapPromise(name: string, fn: Fn<A, B, C, D, E, F, G, H>): void;
-		tapPromise(option: object, fn: Fn<A, B, C, D, E, F, G, H>): void;
-	}
+declare class Hook<A, B, C, D, E, F, G, H> {
+	constructor(args?: string[]);
+	call: FnCall<A, B, C, D, E, F, G, H>;
+	tap(name: string, fn: FnUse<A, B, C, D, E, F, G, H>): void;
+	tap(option: Option, fn: FnUse<A, B, C, D, E, F, G, H>): void;
+	withOptions(options: object): this;
+	isUsed(): boolean;
+	intercept(interceptor: Interceptor): void;
+}
+declare class AsyncHook<A, B, C, D, E, F, G, H> extends Hook<A, B, C, D, E, F, G, H> {
+	callAsync: FnCall<A, B, C, D, E, F, G, H>;
+	promise: (a?: A, b?: B, c?: C, d?: D, e?: E, f?: F, g?: G, h?: H, ...args: any[]) => Promise<any>;
+	tapAsync(name: string, fn: FnUse<A, B, C, D, E, F, G, H>): void;
+	tapAsync(option: object, fn: FnUse<A, B, C, D, E, F, G, H>): void;
+	tapPromise(name: string, fn: FnUse<A, B, C, D, E, F, G, H>): void;
+	tapPromise(option: object, fn: FnUse<A, B, C, D, E, F, G, H>): void;
+}
 
-	export class SyncHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
-	export class SyncBailHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
-	export class SyncWaterfallHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
-	export class SyncLoopHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
+export class SyncHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
+export class SyncBailHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
+export class SyncWaterfallHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
+export class SyncLoopHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
 
-	export class AsyncParallelHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
-	export class AsyncParallelBailHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
-	export class AsyncSequencialHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
-	export class AsyncSequencialBailHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
-	export class AsyncWaterfallHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+export class AsyncParallelHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+export class AsyncParallelBailHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+export class AsyncSequencialHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+export class AsyncSequencialBailHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+export class AsyncWaterfallHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
 
-	interface Plugin {
-		apply(tapable: Tapable): void;
-	}
+interface Plugin {
+	apply(tapable: Tapable): void;
+}
 
-	interface Option {
-		name: string;
-		fn?: Function;
-	}
+interface Option {
+	name: string;
+	fn?: Function;
+}
 
-	interface CompatOption extends Option {
-		names: Set<string>;
-	}
+interface CompatOption extends Option {
+	names: Set<string>;
+}
 
-	interface Interceptor {
-		loop: Function;
-		call: Function;
-		tap: Function;
-	}
-
+interface Interceptor {
+	loop: Function;
+	call: Function;
+	tap: Function;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,63 @@
+declare module "tapable" {
+	/**
+	 * @deprecated
+	 */
+	export abstract class Tapable {
+		static addCompatLayer<T>(instance: T): T & Tapable;
+
+		abstract hooks: Record<string, Hook<any, any, any, any, any, any, any, any>>;
+		protected _pluginCompat: SyncBailHook<CompatOption>;
+		apply(...tapables: Plugin[]): void;
+		plugin(name: string, fn: Function): void;
+	}
+
+	type Fn<A, B, C, D, E, F, G, H> = (a?: A, b?: B, c?: C, d?: D, e?: E, f?: F, g?: G, h?: H, ...args: any[]) => any;
+
+	class Hook<A, B, C, D, E, F, G, H> {
+		call: Fn<A, B, C, D, E, F, G, H>;
+		tap(name: string, fn: Fn<A, B, C, D, E, F, G, H>): void;
+		tap(option: Option, fn: Fn<A, B, C, D, E, F, G, H>): void;
+		withOptions(options: object): this;
+		isUsed(): boolean;
+		intercept(interceptor: Interceptor): void;
+	}
+	class AsyncHook<A, B, C, D, E, F, G, H> extends Hook<A, B, C, D, E, F, G, H> {
+		callAsync: Fn<A, B, C, D, E, F, G, H>;
+		promise: (a?: A, b?: B, c?: C, d?: D, e?: E, f?: F, g?: G, h?: H, ...args: any[]) => Promise<any>;
+		tapAsync(name: string, fn: Fn<A, B, C, D, E, F, G, H>): void;
+		tapAsync(option: object, fn: Fn<A, B, C, D, E, F, G, H>): void;
+		tapPromise(name: string, fn: Fn<A, B, C, D, E, F, G, H>): void;
+		tapPromise(option: object, fn: Fn<A, B, C, D, E, F, G, H>): void;
+	}
+
+	export class SyncHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
+	export class SyncBailHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
+	export class SyncWaterfallHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
+	export class SyncLoopHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends Hook<A, B, C, D, E, F, G, H> {}
+
+	export class AsyncParallelHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+	export class AsyncParallelBailHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+	export class AsyncSequencialHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+	export class AsyncSequencialBailHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+	export class AsyncWaterfallHook<A=any, B=any, C=any, D=any, E=any, F=any, G=any, H=any> extends AsyncHook<A, B, C, D, E, F, G, H> {}
+
+	interface Plugin {
+		apply(tapable: Tapable): void;
+	}
+
+	interface Option {
+		name: string;
+		fn?: Function;
+	}
+
+	interface CompatOption extends Option {
+		names: Set<string>;
+	}
+
+	interface Interceptor {
+		loop: Function;
+		call: Function;
+		tap: Function;
+	}
+
+}

--- a/types/test/test.ts
+++ b/types/test/test.ts
@@ -1,0 +1,78 @@
+import {
+	SyncHook,
+	SyncBailHook,
+	SyncWaterfallHook,
+	SyncLoopHook,
+	AsyncParallelHook,
+	AsyncParallelBailHook,
+	AsyncSequencialHook,
+	AsyncSequencialBailHook,
+	AsyncWaterfallHook
+ } from "../index";
+
+declare class List<T> {
+	getRoutes(): T[];
+	add(t: T): void;
+}
+
+interface Route {
+	_routeBrand: any;
+}
+
+declare function findRoutePromise(source: string, target: string): Promise<Route>
+declare function findRouteCallback(source: string, target: string, fn: Function): void
+declare function cacheGet(source: string, target: string): Route
+
+class Car {
+	hooks = {
+		accelerate: new SyncHook<number>(["newSpeed"]),
+		break: new SyncHook(),
+		calculateRoutes: new AsyncParallelHook<string, string, List<Route>>(["source", "target", "routesList"])
+	};
+
+	setSpeed(newSpeed: number) {
+		this.hooks.accelerate.call(newSpeed);
+	}
+
+	useNavigationSystemPromise(source: string, target: string) {
+		const routesList = new List<Route>();
+		return this.hooks.calculateRoutes.promise(source, target, routesList).then(() => {
+			return routesList.getRoutes();
+		});
+	}
+
+	useNavigationSystemAsync(source: string, target: string, callback: Function) {
+		const routesList = new List<Route>();
+		this.hooks.calculateRoutes.callAsync(source, target, routesList, (err: any) => {
+			if(err) return callback(err);
+			callback(null, routesList.getRoutes());
+		});
+	}
+}
+
+const myCar = new Car();
+
+// Use the tap method to add a consument
+myCar.hooks.break.tap("WarningLampPlugin", () => console.log("warningLamp on"));
+
+myCar.hooks.calculateRoutes.tapPromise("GoogleMapsPlugin", (source, target, routesList) => {
+	// return a promise
+	return findRoutePromise(source, target).then(route => {
+		routesList.add(route);
+	});
+});
+myCar.hooks.calculateRoutes.tapAsync("BingMapsPlugin", (source, target, routesList, callback) => {
+	findRouteCallback(source, target, (err: any, route: any) => {
+		if(err) return callback(err);
+		routesList.add(route);
+		// call the callback
+		callback();
+	});
+});
+
+// You can still use sync plugins
+myCar.hooks.calculateRoutes.tap("CachedRoutesPlugin", (source, target, routesList) => {
+	const cachedRoute = cacheGet(source, target);
+	if(cachedRoute)
+		routesList.add(cachedRoute);
+})

--- a/types/test/tsconfig.json
+++ b/types/test/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "noEmit": true,
-        "lib": [ "es2015" ]
+        "lib": [ "es2015", "dom" ]
     },
     "include": [
         "./*.ts"

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "lib": [ "es2015" ]
+    },
+    "include": [
+        "./*.ts"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,6 +2736,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+typescript@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"


### PR DESCRIPTION
This pull request is for typing tapable's new API.
The typing is shipped within the package of tapable, rather than on DT. This is better in terms of developer experience since users only need to install one package.

The typing is summarized from both README and source code. If something is wrong, please tell me!

For implementation detail, I'm using generic default to provide sensible type inference and moderate checking. Tapable's new API uses variadic arguments a lot, which is hard to model in type system. (Not that hard if https://github.com/Microsoft/TypeScript/issues/5453 is implemented). 

I have to pack more type parameters into one class in order to support multiple argument types. So users can write `const hook = new SyncHook<string>(["param"])`, and `hook.call('param')` will be correctly typed. On the other hand, passing more arguments won't trigger compiling error, so callback function can be used.

We can, however, make the export API as function instead of class. TtypeScript/FlowType can support overloaded function, so we can add to one hook more signatures that return different types respectively.

cc @TheLarkInn 