### PR TITLE
fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ const {
 	SyncLoopHook,
 	AsyncParallelHook,
 	AsyncParallelBailHook,
-	AsyncSequencialHook,
-	AsyncSequencialBailHook,
-	AsyncWaterfallHook
+	AsyncSeriesHook,
+	AsyncSeriesBailHook,
+	AsyncSeriesWaterfallHook
  } = require("tapable");
 ```
 


### PR DESCRIPTION
Some Hook classes just renamed, should synchronize with README.md