### PR TITLE
Make Promise hooks easier to debug

### DIFF
--- a/lib/HookCodeFactory.js
+++ b/lib/HookCodeFactory.js
@@ -164,12 +164,12 @@ class HookCodeFactory {
 				break;
 			case "promise":
 				code += `var _hasResult${tapIndex} = false;\n`;
-				code += `var p = _fn${tapIndex}(${this.args({
+				code += `var _promise${tapIndex} = _fn${tapIndex}(${this.args({
 					before: tap.context ? "_context" : undefined
 				})});\n`;
-				code += `if (!(p && p.then))\n`;
-				code += `  throw new Error('Callback did not return promise. Code:\\n\\n' + _fn${tapIndex} +'\\n\\nResult: '+p+'\\n');\n`;
-				code += `p.then(_result${tapIndex} => {\n`;
+				code += `if (!_promise${tapIndex} || !_promise${tapIndex}.then)\n`;
+				code += `  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise${tapIndex} + ')');\n`;
+				code += `_promise${tapIndex}.then(_result${tapIndex} => {\n`;
 				code += `_hasResult${tapIndex} = true;\n`;
 				if(onResult) {
 					code += onResult(`_result${tapIndex}`);

--- a/lib/HookCodeFactory.js
+++ b/lib/HookCodeFactory.js
@@ -164,9 +164,12 @@ class HookCodeFactory {
 				break;
 			case "promise":
 				code += `var _hasResult${tapIndex} = false;\n`;
-				code += `_fn${tapIndex}(${this.args({
+				code += `var p = _fn${tapIndex}(${this.args({
 					before: tap.context ? "_context" : undefined
-				})}).then(_result${tapIndex} => {\n`;
+				})});\n`;
+				code += `if (!(p && p.then))\n`;
+				code += `  throw new Error('Callback did not return promise. Code:\\n\\n' + _fn${tapIndex} +'\\n\\nResult: '+p+'\\n');\n`;
+				code += `p.then(_result${tapIndex} => {\n`;
 				code += `_hasResult${tapIndex} = true;\n`;
 				if(onResult) {
 					code += onResult(`_result${tapIndex}`);

--- a/lib/__tests__/HookTester.js
+++ b/lib/__tests__/HookTester.js
@@ -70,6 +70,11 @@ class HookTester {
 
 	async runForLoopAsync(result, method) {
 		{
+			const hook = this.createHook([], `${method}BrokenPromise`);
+			hook.tapPromise("promise", () => "this is not a promise");
+			result[`${method}BrokenPromise`] = await this.gainResult(cb => hook[method](cb));
+		}
+		{
 			const hook = this.createHook([], `${method}SinglePromise`);
 			hook.tapPromise("promise", () => {
 				result[`${method}SinglePromiseCalled`] = (result[`${method}SinglePromiseCalled`] || 0) + 1;

--- a/lib/__tests__/__snapshots__/AsyncSeriesHooks.js.snap
+++ b/lib/__tests__/__snapshots__/AsyncSeriesHooks.js.snap
@@ -1432,12 +1432,7 @@ exports[`AsyncSeriesLoopHook should have to correct behavior 1`] = `
 Object {
   "async": Object {
     "callAsyncBrokenPromise": Object {
-      "error": "Callback did not return promise. Code:
-
-() => \\"this is not a promise\\"
-
-Result: this is not a promise
-",
+      "error": "Tap function (tapPromise) did not return promise (returned this is not a promise)",
     },
     "callAsyncMixed": Object {
       "type": "async",
@@ -1469,12 +1464,7 @@ Result: this is not a promise
     },
     "callAsyncSinglePromiseCalled": 42,
     "promiseBrokenPromise": Object {
-      "error": "Callback did not return promise. Code:
-
-() => \\"this is not a promise\\"
-
-Result: this is not a promise
-",
+      "error": "Tap function (tapPromise) did not return promise (returned this is not a promise)",
       "type": "promise",
     },
     "promiseMixed": Object {

--- a/lib/__tests__/__snapshots__/AsyncSeriesHooks.js.snap
+++ b/lib/__tests__/__snapshots__/AsyncSeriesHooks.js.snap
@@ -1431,6 +1431,14 @@ Object {
 exports[`AsyncSeriesLoopHook should have to correct behavior 1`] = `
 Object {
   "async": Object {
+    "callAsyncBrokenPromise": Object {
+      "error": "Callback did not return promise. Code:
+
+() => \\"this is not a promise\\"
+
+Result: this is not a promise
+",
+    },
     "callAsyncMixed": Object {
       "type": "async",
       "value": undefined,
@@ -1460,6 +1468,15 @@ Object {
       "value": undefined,
     },
     "callAsyncSinglePromiseCalled": 42,
+    "promiseBrokenPromise": Object {
+      "error": "Callback did not return promise. Code:
+
+() => \\"this is not a promise\\"
+
+Result: this is not a promise
+",
+      "type": "promise",
+    },
     "promiseMixed": Object {
       "type": "promise",
       "value": undefined,

--- a/lib/__tests__/__snapshots__/HookCodeFactory.js.snap
+++ b/lib/__tests__/__snapshots__/HookCodeFactory.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HookCodeFactory callTap (no args, no intercept) async with onResult 1`] = `
-"var _fn1 = this._x[1];
+"var _fn1 = _x[1];
 _fn1((_err1, _result1) => {
 if(_err1) {
 onError(_err1);
@@ -13,7 +13,7 @@ onResult(_result1);
 `;
 
 exports[`HookCodeFactory callTap (no args, no intercept) async without onResult 1`] = `
-"var _fn1 = this._x[1];
+"var _fn1 = _x[1];
 _fn1(_err1 => {
 if(_err1) {
 onError(_err1);
@@ -25,7 +25,7 @@ onDone();
 `;
 
 exports[`HookCodeFactory callTap (no args, no intercept) promise with onResult 1`] = `
-"var _fn2 = this._x[2];
+"var _fn2 = _x[2];
 var _hasResult2 = false;
 _fn2().then(_result2 => {
 _hasResult2 = true;
@@ -38,7 +38,7 @@ onError(_err2);
 `;
 
 exports[`HookCodeFactory callTap (no args, no intercept) promise without onResult 1`] = `
-"var _fn2 = this._x[2];
+"var _fn2 = _x[2];
 var _hasResult2 = false;
 _fn2().then(_result2 => {
 _hasResult2 = true;
@@ -51,7 +51,7 @@ onError(_err2);
 `;
 
 exports[`HookCodeFactory callTap (no args, no intercept) sync with onResult 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _hasError0 = false;
 try {
 var _result0 = _fn0();
@@ -66,7 +66,7 @@ onResult(_result0);
 `;
 
 exports[`HookCodeFactory callTap (no args, no intercept) sync without onResult 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _hasError0 = false;
 try {
 _fn0();
@@ -81,7 +81,7 @@ onDone();
 `;
 
 exports[`HookCodeFactory callTap (with args, no intercept) async with onResult 1`] = `
-"var _fn1 = this._x[1];
+"var _fn1 = _x[1];
 _fn1(a, b, c, (_err1, _result1) => {
 if(_err1) {
 onError(_err1);
@@ -93,7 +93,7 @@ onResult(_result1);
 `;
 
 exports[`HookCodeFactory callTap (with args, no intercept) async without onResult 1`] = `
-"var _fn1 = this._x[1];
+"var _fn1 = _x[1];
 _fn1(a, b, c, _err1 => {
 if(_err1) {
 onError(_err1);
@@ -105,7 +105,7 @@ onDone();
 `;
 
 exports[`HookCodeFactory callTap (with args, no intercept) promise with onResult 1`] = `
-"var _fn2 = this._x[2];
+"var _fn2 = _x[2];
 var _hasResult2 = false;
 _fn2(a, b, c).then(_result2 => {
 _hasResult2 = true;
@@ -118,7 +118,7 @@ onError(_err2);
 `;
 
 exports[`HookCodeFactory callTap (with args, no intercept) promise without onResult 1`] = `
-"var _fn2 = this._x[2];
+"var _fn2 = _x[2];
 var _hasResult2 = false;
 _fn2(a, b, c).then(_result2 => {
 _hasResult2 = true;
@@ -131,7 +131,7 @@ onError(_err2);
 `;
 
 exports[`HookCodeFactory callTap (with args, no intercept) sync with onResult 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _hasError0 = false;
 try {
 var _result0 = _fn0(a, b, c);
@@ -146,7 +146,7 @@ onResult(_result0);
 `;
 
 exports[`HookCodeFactory callTap (with args, no intercept) sync without onResult 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _hasError0 = false;
 try {
 _fn0(a, b, c);
@@ -161,10 +161,10 @@ onDone();
 `;
 
 exports[`HookCodeFactory callTap (with args, with intercept) async with onResult 1`] = `
-"var _tap1 = this.taps[1];
-this.interceptors[0].tap(_tap1);
-this.interceptors[1].tap(_tap1);
-var _fn1 = this._x[1];
+"var _tap1 = _taps[1];
+_interceptors[0].tap(_tap1);
+_interceptors[1].tap(_tap1);
+var _fn1 = _x[1];
 _fn1(a, b, c, (_err1, _result1) => {
 if(_err1) {
 onError(_err1);
@@ -176,10 +176,10 @@ onResult(_result1);
 `;
 
 exports[`HookCodeFactory callTap (with args, with intercept) async without onResult 1`] = `
-"var _tap1 = this.taps[1];
-this.interceptors[0].tap(_tap1);
-this.interceptors[1].tap(_tap1);
-var _fn1 = this._x[1];
+"var _tap1 = _taps[1];
+_interceptors[0].tap(_tap1);
+_interceptors[1].tap(_tap1);
+var _fn1 = _x[1];
 _fn1(a, b, c, _err1 => {
 if(_err1) {
 onError(_err1);
@@ -191,10 +191,10 @@ onDone();
 `;
 
 exports[`HookCodeFactory callTap (with args, with intercept) promise with onResult 1`] = `
-"var _tap2 = this.taps[2];
-this.interceptors[0].tap(_tap2);
-this.interceptors[1].tap(_tap2);
-var _fn2 = this._x[2];
+"var _tap2 = _taps[2];
+_interceptors[0].tap(_tap2);
+_interceptors[1].tap(_tap2);
+var _fn2 = _x[2];
 var _hasResult2 = false;
 _fn2(a, b, c).then(_result2 => {
 _hasResult2 = true;
@@ -207,10 +207,10 @@ onError(_err2);
 `;
 
 exports[`HookCodeFactory callTap (with args, with intercept) promise without onResult 1`] = `
-"var _tap2 = this.taps[2];
-this.interceptors[0].tap(_tap2);
-this.interceptors[1].tap(_tap2);
-var _fn2 = this._x[2];
+"var _tap2 = _taps[2];
+_interceptors[0].tap(_tap2);
+_interceptors[1].tap(_tap2);
+var _fn2 = _x[2];
 var _hasResult2 = false;
 _fn2(a, b, c).then(_result2 => {
 _hasResult2 = true;
@@ -223,10 +223,10 @@ onError(_err2);
 `;
 
 exports[`HookCodeFactory callTap (with args, with intercept) sync with onResult 1`] = `
-"var _tap0 = this.taps[0];
-this.interceptors[0].tap(_tap0);
-this.interceptors[1].tap(_tap0);
-var _fn0 = this._x[0];
+"var _tap0 = _taps[0];
+_interceptors[0].tap(_tap0);
+_interceptors[1].tap(_tap0);
+var _fn0 = _x[0];
 var _hasError0 = false;
 try {
 var _result0 = _fn0(a, b, c);
@@ -241,10 +241,10 @@ onResult(_result0);
 `;
 
 exports[`HookCodeFactory callTap (with args, with intercept) sync without onResult 1`] = `
-"var _tap0 = this.taps[0];
-this.interceptors[0].tap(_tap0);
-this.interceptors[1].tap(_tap0);
-var _fn0 = this._x[0];
+"var _tap0 = _taps[0];
+_interceptors[0].tap(_tap0);
+_interceptors[1].tap(_tap0);
+var _fn0 = _x[0];
 var _hasError0 = false;
 try {
 _fn0(a, b, c);
@@ -264,7 +264,7 @@ var _loopAsync = false;
 var _loop;
 do {
 _loop = false;
-var _fn0 = this._x[0];
+var _fn0 = _x[0];
 var _hasError0 = false;
 try {
 var _result0 = _fn0(a, b, c);
@@ -277,7 +277,7 @@ if(_result0 !== undefined) {
 _loop = true;
 if(_loopAsync) _looper();
 } else {
-var _fn1 = this._x[1];
+var _fn1 = _x[1];
 _fn1(a, b, c, (_err1, _result1) => {
 if(_err1) {
 onError(1, _err1);
@@ -286,7 +286,7 @@ if(_result1 !== undefined) {
 _loop = true;
 if(_loopAsync) _looper();
 } else {
-var _fn2 = this._x[2];
+var _fn2 = _x[2];
 var _hasResult2 = false;
 _fn2(a, b, c).then(_result2 => {
 _hasResult2 = true;
@@ -321,7 +321,7 @@ var _done = () => {
 onDone();
 };
 if(_counter <= 0) break;
-var _fn0 = this._x[0];
+var _fn0 = _x[0];
 var _result0 = _fn0(a, b, c);
 if(_counter > 0) {
 onResult(0, _result0, () => {
@@ -332,7 +332,7 @@ _done();
 });
 }
 if(_counter <= 0) break;
-var _fn1 = this._x[1];
+var _fn1 = _x[1];
 _fn1(a, b, c, (_err1, _result1) => {
 if(_err1) {
 if(_counter > 0) {
@@ -350,7 +350,7 @@ _done();
 }
 });
 if(_counter <= 0) break;
-var _fn2 = this._x[2];
+var _fn2 = _x[2];
 var _hasResult2 = false;
 _fn2(a, b, c).then(_result2 => {
 _hasResult2 = true;
@@ -373,16 +373,16 @@ onError(2, _err2);
 `;
 
 exports[`HookCodeFactory taps (mixed) callTapsSeries 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _result0 = _fn0(a, b, c);
 onResult(0, _result0, () => {
-var _fn1 = this._x[1];
+var _fn1 = _x[1];
 _fn1(a, b, c, (_err1, _result1) => {
 if(_err1) {
 onError(1, _err1);
 } else {
 onResult(1, _result1, () => {
-var _fn2 = this._x[2];
+var _fn2 = _x[2];
 var _hasResult2 = false;
 _fn2(a, b, c).then(_result2 => {
 _hasResult2 = true;
@@ -412,7 +412,7 @@ var _loopAsync = false;
 var _loop;
 do {
 _loop = false;
-var _fn0 = this._x[0];
+var _fn0 = _x[0];
 _fn0(a, b, c, (_err0, _result0) => {
 if(_err0) {
 onError(0, _err0);
@@ -421,7 +421,7 @@ if(_result0 !== undefined) {
 _loop = true;
 if(_loopAsync) _looper();
 } else {
-var _fn1 = this._x[1];
+var _fn1 = _x[1];
 var _hasResult1 = false;
 _fn1(a, b, c).then(_result1 => {
 _hasResult1 = true;
@@ -429,7 +429,7 @@ if(_result1 !== undefined) {
 _loop = true;
 if(_loopAsync) _looper();
 } else {
-var _fn2 = this._x[2];
+var _fn2 = _x[2];
 var _hasError2 = false;
 try {
 var _result2 = _fn2(a, b, c);
@@ -469,7 +469,7 @@ var _done = () => {
 onDone();
 };
 if(_counter <= 0) break;
-var _fn0 = this._x[0];
+var _fn0 = _x[0];
 _fn0(a, b, c, (_err0, _result0) => {
 if(_err0) {
 if(_counter > 0) {
@@ -487,7 +487,7 @@ _done();
 }
 });
 if(_counter <= 0) break;
-var _fn1 = this._x[1];
+var _fn1 = _x[1];
 var _hasResult1 = false;
 _fn1(a, b, c).then(_result1 => {
 _hasResult1 = true;
@@ -506,7 +506,7 @@ onError(1, _err1);
 }
 });
 if(_counter <= 0) break;
-var _fn2 = this._x[2];
+var _fn2 = _x[2];
 var _result2 = _fn2(a, b, c);
 if(_counter > 0) {
 onResult(2, _result2, () => {
@@ -521,18 +521,18 @@ _done();
 `;
 
 exports[`HookCodeFactory taps (mixed2) callTapsSeries 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 _fn0(a, b, c, (_err0, _result0) => {
 if(_err0) {
 onError(0, _err0);
 } else {
 onResult(0, _result0, () => {
-var _fn1 = this._x[1];
+var _fn1 = _x[1];
 var _hasResult1 = false;
 _fn1(a, b, c).then(_result1 => {
 _hasResult1 = true;
 onResult(1, _result1, () => {
-var _fn2 = this._x[2];
+var _fn2 = _x[2];
 var _hasError2 = false;
 try {
 var _result2 = _fn2(a, b, c);
@@ -566,17 +566,17 @@ exports[`HookCodeFactory taps (multiple sync) callTapsLooping 1`] = `
 "var _loop;
 do {
 _loop = false;
-var _fn0 = this._x[0];
+var _fn0 = _x[0];
 var _result0 = _fn0(a, b, c);
 if(_result0 !== undefined) {
 _loop = true;
 } else {
-var _fn1 = this._x[1];
+var _fn1 = _x[1];
 var _result1 = _fn1(a, b, c);
 if(_result1 !== undefined) {
 _loop = true;
 } else {
-var _fn2 = this._x[2];
+var _fn2 = _x[2];
 var _result2 = _fn2(a, b, c);
 if(_result2 !== undefined) {
 _loop = true;
@@ -598,7 +598,7 @@ var _done = () => {
 onDone();
 };
 if(_counter <= 0) break;
-var _fn0 = this._x[0];
+var _fn0 = _x[0];
 var _result0 = _fn0(a, b, c);
 if(_counter > 0) {
 onResult(0, _result0, () => {
@@ -609,7 +609,7 @@ _done();
 });
 }
 if(_counter <= 0) break;
-var _fn1 = this._x[1];
+var _fn1 = _x[1];
 var _result1 = _fn1(a, b, c);
 if(_counter > 0) {
 onResult(1, _result1, () => {
@@ -620,7 +620,7 @@ _done();
 });
 }
 if(_counter <= 0) break;
-var _fn2 = this._x[2];
+var _fn2 = _x[2];
 var _result2 = _fn2(a, b, c);
 if(_counter > 0) {
 onResult(2, _result2, () => {
@@ -635,13 +635,13 @@ _done();
 `;
 
 exports[`HookCodeFactory taps (multiple sync) callTapsSeries 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _result0 = _fn0(a, b, c);
 onResult(0, _result0, () => {
-var _fn1 = this._x[1];
+var _fn1 = _x[1];
 var _result1 = _fn1(a, b, c);
 onResult(1, _result1, () => {
-var _fn2 = this._x[2];
+var _fn2 = _x[2];
 var _result2 = _fn2(a, b, c);
 onResult(2, _result2, () => {
 onDone();
@@ -678,7 +678,7 @@ var _loopAsync = false;
 var _loop;
 do {
 _loop = false;
-var _fn0 = this._x[0];
+var _fn0 = _x[0];
 _fn0(a, b, c, (_err0, _result0) => {
 if(_err0) {
 onError(0, _err0);
@@ -701,7 +701,7 @@ _looper();
 `;
 
 exports[`HookCodeFactory taps (single async) callTapsParallel 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 _fn0(a, b, c, (_err0, _result0) => {
 if(_err0) {
 onError(0, _err0);
@@ -717,7 +717,7 @@ onDone();
 `;
 
 exports[`HookCodeFactory taps (single async) callTapsSeries 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 _fn0(a, b, c, (_err0, _result0) => {
 if(_err0) {
 onError(0, _err0);
@@ -738,7 +738,7 @@ var _loopAsync = false;
 var _loop;
 do {
 _loop = false;
-var _fn0 = this._x[0];
+var _fn0 = _x[0];
 var _hasResult0 = false;
 _fn0(a, b, c).then(_result0 => {
 _hasResult0 = true;
@@ -762,7 +762,7 @@ _looper();
 `;
 
 exports[`HookCodeFactory taps (single promise) callTapsParallel 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _hasResult0 = false;
 _fn0(a, b, c).then(_result0 => {
 _hasResult0 = true;
@@ -779,7 +779,7 @@ onError(0, _err0);
 `;
 
 exports[`HookCodeFactory taps (single promise) callTapsSeries 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _hasResult0 = false;
 _fn0(a, b, c).then(_result0 => {
 _hasResult0 = true;
@@ -799,7 +799,7 @@ exports[`HookCodeFactory taps (single sync) callTapsLooping 1`] = `
 "var _loop;
 do {
 _loop = false;
-var _fn0 = this._x[0];
+var _fn0 = _x[0];
 var _result0 = _fn0(a, b, c);
 if(_result0 !== undefined) {
 _loop = true;
@@ -813,7 +813,7 @@ onDone();
 `;
 
 exports[`HookCodeFactory taps (single sync) callTapsParallel 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _result0 = _fn0(a, b, c);
 onResult(0, _result0, () => {
 onDone();
@@ -824,7 +824,7 @@ onDone();
 `;
 
 exports[`HookCodeFactory taps (single sync) callTapsSeries 1`] = `
-"var _fn0 = this._x[0];
+"var _fn0 = _x[0];
 var _result0 = _fn0(a, b, c);
 onResult(0, _result0, () => {
 onDone();

--- a/lib/__tests__/__snapshots__/HookCodeFactory.js.snap
+++ b/lib/__tests__/__snapshots__/HookCodeFactory.js.snap
@@ -27,10 +27,10 @@ onDone();
 exports[`HookCodeFactory callTap (no args, no intercept) promise with onResult 1`] = `
 "var _fn2 = _x[2];
 var _hasResult2 = false;
-var p = _fn2();
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result2 => {
+var _promise2 = _fn2();
+if (!_promise2 || !_promise2.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
+_promise2.then(_result2 => {
 _hasResult2 = true;
 onResult(_result2);
 }, _err2 => {
@@ -43,10 +43,10 @@ onError(_err2);
 exports[`HookCodeFactory callTap (no args, no intercept) promise without onResult 1`] = `
 "var _fn2 = _x[2];
 var _hasResult2 = false;
-var p = _fn2();
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result2 => {
+var _promise2 = _fn2();
+if (!_promise2 || !_promise2.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
+_promise2.then(_result2 => {
 _hasResult2 = true;
 onDone();
 }, _err2 => {
@@ -113,10 +113,10 @@ onDone();
 exports[`HookCodeFactory callTap (with args, no intercept) promise with onResult 1`] = `
 "var _fn2 = _x[2];
 var _hasResult2 = false;
-var p = _fn2(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result2 => {
+var _promise2 = _fn2(a, b, c);
+if (!_promise2 || !_promise2.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
+_promise2.then(_result2 => {
 _hasResult2 = true;
 onResult(_result2);
 }, _err2 => {
@@ -129,10 +129,10 @@ onError(_err2);
 exports[`HookCodeFactory callTap (with args, no intercept) promise without onResult 1`] = `
 "var _fn2 = _x[2];
 var _hasResult2 = false;
-var p = _fn2(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result2 => {
+var _promise2 = _fn2(a, b, c);
+if (!_promise2 || !_promise2.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
+_promise2.then(_result2 => {
 _hasResult2 = true;
 onDone();
 }, _err2 => {
@@ -208,10 +208,10 @@ _interceptors[0].tap(_tap2);
 _interceptors[1].tap(_tap2);
 var _fn2 = _x[2];
 var _hasResult2 = false;
-var p = _fn2(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result2 => {
+var _promise2 = _fn2(a, b, c);
+if (!_promise2 || !_promise2.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
+_promise2.then(_result2 => {
 _hasResult2 = true;
 onResult(_result2);
 }, _err2 => {
@@ -227,10 +227,10 @@ _interceptors[0].tap(_tap2);
 _interceptors[1].tap(_tap2);
 var _fn2 = _x[2];
 var _hasResult2 = false;
-var p = _fn2(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result2 => {
+var _promise2 = _fn2(a, b, c);
+if (!_promise2 || !_promise2.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
+_promise2.then(_result2 => {
 _hasResult2 = true;
 onDone();
 }, _err2 => {
@@ -306,10 +306,10 @@ if(_loopAsync) _looper();
 } else {
 var _fn2 = _x[2];
 var _hasResult2 = false;
-var p = _fn2(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result2 => {
+var _promise2 = _fn2(a, b, c);
+if (!_promise2 || !_promise2.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
+_promise2.then(_result2 => {
 _hasResult2 = true;
 if(_result2 !== undefined) {
 _loop = true;
@@ -373,10 +373,10 @@ _done();
 if(_counter <= 0) break;
 var _fn2 = _x[2];
 var _hasResult2 = false;
-var p = _fn2(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result2 => {
+var _promise2 = _fn2(a, b, c);
+if (!_promise2 || !_promise2.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
+_promise2.then(_result2 => {
 _hasResult2 = true;
 if(_counter > 0) {
 onResult(2, _result2, () => {
@@ -408,10 +408,10 @@ onError(1, _err1);
 onResult(1, _result1, () => {
 var _fn2 = _x[2];
 var _hasResult2 = false;
-var p = _fn2(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result2 => {
+var _promise2 = _fn2(a, b, c);
+if (!_promise2 || !_promise2.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
+_promise2.then(_result2 => {
 _hasResult2 = true;
 onResult(2, _result2, () => {
 onDone();
@@ -450,10 +450,10 @@ if(_loopAsync) _looper();
 } else {
 var _fn1 = _x[1];
 var _hasResult1 = false;
-var p = _fn1(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn1 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result1 => {
+var _promise1 = _fn1(a, b, c);
+if (!_promise1 || !_promise1.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise1 + ')');
+_promise1.then(_result1 => {
 _hasResult1 = true;
 if(_result1 !== undefined) {
 _loop = true;
@@ -519,10 +519,10 @@ _done();
 if(_counter <= 0) break;
 var _fn1 = _x[1];
 var _hasResult1 = false;
-var p = _fn1(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn1 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result1 => {
+var _promise1 = _fn1(a, b, c);
+if (!_promise1 || !_promise1.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise1 + ')');
+_promise1.then(_result1 => {
 _hasResult1 = true;
 if(_counter > 0) {
 onResult(1, _result1, () => {
@@ -562,10 +562,10 @@ onError(0, _err0);
 onResult(0, _result0, () => {
 var _fn1 = _x[1];
 var _hasResult1 = false;
-var p = _fn1(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn1 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result1 => {
+var _promise1 = _fn1(a, b, c);
+if (!_promise1 || !_promise1.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise1 + ')');
+_promise1.then(_result1 => {
 _hasResult1 = true;
 onResult(1, _result1, () => {
 var _fn2 = _x[2];
@@ -776,10 +776,10 @@ do {
 _loop = false;
 var _fn0 = _x[0];
 var _hasResult0 = false;
-var p = _fn0(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn0 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result0 => {
+var _promise0 = _fn0(a, b, c);
+if (!_promise0 || !_promise0.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise0 + ')');
+_promise0.then(_result0 => {
 _hasResult0 = true;
 if(_result0 !== undefined) {
 _loop = true;
@@ -803,10 +803,10 @@ _looper();
 exports[`HookCodeFactory taps (single promise) callTapsParallel 1`] = `
 "var _fn0 = _x[0];
 var _hasResult0 = false;
-var p = _fn0(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn0 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result0 => {
+var _promise0 = _fn0(a, b, c);
+if (!_promise0 || !_promise0.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise0 + ')');
+_promise0.then(_result0 => {
 _hasResult0 = true;
 onResult(0, _result0, () => {
 onDone();
@@ -823,10 +823,10 @@ onError(0, _err0);
 exports[`HookCodeFactory taps (single promise) callTapsSeries 1`] = `
 "var _fn0 = _x[0];
 var _hasResult0 = false;
-var p = _fn0(a, b, c);
-if (!(p && p.then))
-  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn0 +'\\\\n\\\\nResult: '+p+'\\\\n');
-p.then(_result0 => {
+var _promise0 = _fn0(a, b, c);
+if (!_promise0 || !_promise0.then)
+  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise0 + ')');
+_promise0.then(_result0 => {
 _hasResult0 = true;
 onResult(0, _result0, () => {
 onDone();

--- a/lib/__tests__/__snapshots__/HookCodeFactory.js.snap
+++ b/lib/__tests__/__snapshots__/HookCodeFactory.js.snap
@@ -27,7 +27,10 @@ onDone();
 exports[`HookCodeFactory callTap (no args, no intercept) promise with onResult 1`] = `
 "var _fn2 = _x[2];
 var _hasResult2 = false;
-_fn2().then(_result2 => {
+var p = _fn2();
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result2 => {
 _hasResult2 = true;
 onResult(_result2);
 }, _err2 => {
@@ -40,7 +43,10 @@ onError(_err2);
 exports[`HookCodeFactory callTap (no args, no intercept) promise without onResult 1`] = `
 "var _fn2 = _x[2];
 var _hasResult2 = false;
-_fn2().then(_result2 => {
+var p = _fn2();
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result2 => {
 _hasResult2 = true;
 onDone();
 }, _err2 => {
@@ -107,7 +113,10 @@ onDone();
 exports[`HookCodeFactory callTap (with args, no intercept) promise with onResult 1`] = `
 "var _fn2 = _x[2];
 var _hasResult2 = false;
-_fn2(a, b, c).then(_result2 => {
+var p = _fn2(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result2 => {
 _hasResult2 = true;
 onResult(_result2);
 }, _err2 => {
@@ -120,7 +129,10 @@ onError(_err2);
 exports[`HookCodeFactory callTap (with args, no intercept) promise without onResult 1`] = `
 "var _fn2 = _x[2];
 var _hasResult2 = false;
-_fn2(a, b, c).then(_result2 => {
+var p = _fn2(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result2 => {
 _hasResult2 = true;
 onDone();
 }, _err2 => {
@@ -196,7 +208,10 @@ _interceptors[0].tap(_tap2);
 _interceptors[1].tap(_tap2);
 var _fn2 = _x[2];
 var _hasResult2 = false;
-_fn2(a, b, c).then(_result2 => {
+var p = _fn2(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result2 => {
 _hasResult2 = true;
 onResult(_result2);
 }, _err2 => {
@@ -212,7 +227,10 @@ _interceptors[0].tap(_tap2);
 _interceptors[1].tap(_tap2);
 var _fn2 = _x[2];
 var _hasResult2 = false;
-_fn2(a, b, c).then(_result2 => {
+var p = _fn2(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result2 => {
 _hasResult2 = true;
 onDone();
 }, _err2 => {
@@ -288,7 +306,10 @@ if(_loopAsync) _looper();
 } else {
 var _fn2 = _x[2];
 var _hasResult2 = false;
-_fn2(a, b, c).then(_result2 => {
+var p = _fn2(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result2 => {
 _hasResult2 = true;
 if(_result2 !== undefined) {
 _loop = true;
@@ -352,7 +373,10 @@ _done();
 if(_counter <= 0) break;
 var _fn2 = _x[2];
 var _hasResult2 = false;
-_fn2(a, b, c).then(_result2 => {
+var p = _fn2(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result2 => {
 _hasResult2 = true;
 if(_counter > 0) {
 onResult(2, _result2, () => {
@@ -384,7 +408,10 @@ onError(1, _err1);
 onResult(1, _result1, () => {
 var _fn2 = _x[2];
 var _hasResult2 = false;
-_fn2(a, b, c).then(_result2 => {
+var p = _fn2(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn2 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result2 => {
 _hasResult2 = true;
 onResult(2, _result2, () => {
 onDone();
@@ -423,7 +450,10 @@ if(_loopAsync) _looper();
 } else {
 var _fn1 = _x[1];
 var _hasResult1 = false;
-_fn1(a, b, c).then(_result1 => {
+var p = _fn1(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn1 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result1 => {
 _hasResult1 = true;
 if(_result1 !== undefined) {
 _loop = true;
@@ -489,7 +519,10 @@ _done();
 if(_counter <= 0) break;
 var _fn1 = _x[1];
 var _hasResult1 = false;
-_fn1(a, b, c).then(_result1 => {
+var p = _fn1(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn1 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result1 => {
 _hasResult1 = true;
 if(_counter > 0) {
 onResult(1, _result1, () => {
@@ -529,7 +562,10 @@ onError(0, _err0);
 onResult(0, _result0, () => {
 var _fn1 = _x[1];
 var _hasResult1 = false;
-_fn1(a, b, c).then(_result1 => {
+var p = _fn1(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn1 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result1 => {
 _hasResult1 = true;
 onResult(1, _result1, () => {
 var _fn2 = _x[2];
@@ -740,7 +776,10 @@ do {
 _loop = false;
 var _fn0 = _x[0];
 var _hasResult0 = false;
-_fn0(a, b, c).then(_result0 => {
+var p = _fn0(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn0 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result0 => {
 _hasResult0 = true;
 if(_result0 !== undefined) {
 _loop = true;
@@ -764,7 +803,10 @@ _looper();
 exports[`HookCodeFactory taps (single promise) callTapsParallel 1`] = `
 "var _fn0 = _x[0];
 var _hasResult0 = false;
-_fn0(a, b, c).then(_result0 => {
+var p = _fn0(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn0 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result0 => {
 _hasResult0 = true;
 onResult(0, _result0, () => {
 onDone();
@@ -781,7 +823,10 @@ onError(0, _err0);
 exports[`HookCodeFactory taps (single promise) callTapsSeries 1`] = `
 "var _fn0 = _x[0];
 var _hasResult0 = false;
-_fn0(a, b, c).then(_result0 => {
+var p = _fn0(a, b, c);
+if (!(p && p.then))
+  throw new Error('Callback did not return promise. Code:\\\\n\\\\n' + _fn0 +'\\\\n\\\\nResult: '+p+'\\\\n');
+p.then(_result0 => {
 _hasResult0 = true;
 onResult(0, _result0, () => {
 onDone();


### PR DESCRIPTION
Had a problem with a callback not returning a Promise, this made it easier to debug.

Not sure if instead the callback should instead always be wrapped in a Promise so that it doesn't matter…

I had to update the snapshot beforehand, it was wrong on master apparently.