### PR TITLE
Merge an original tap with the modified one instead of replacing

### DIFF
--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -76,9 +76,7 @@ class Hook {
 	_runRegisterInterceptors(options) {
 		for(const interceptor of this.interceptors) {
 			if(interceptor.register) {
-				const newOptions = interceptor.register(options);
-				if(newOptions !== undefined)
-					options = newOptions;
+				options = Object.assign({}, options, interceptor.register(options));
 			}
 		}
 		return options;
@@ -109,7 +107,7 @@ class Hook {
 		this.interceptors.push(Object.assign({}, interceptor));
 		if(interceptor.register) {
 			for(let i = 0; i < this.taps.length; i++)
-				this.taps[i] = interceptor.register(this.taps[i]);
+				this.taps[i] = Object.assign({}, this.taps[i], interceptor.register(this.taps[i]));
 		}
 	}
 


### PR DESCRIPTION
This change will address the issue webpack/webpack#6779

It is happening because  `interceptor.register` currently replaces an original tap with a modified one. 

Currently, `makeInterceptorFor` function in `ProfilingPlugin` will return the interceptor with `register` function which returns a modified tap without `context` propery. Therefore, all the taps will lose its `context` property once `ProfilingPlugin` is applied.
```js
const makeInterceptorFor = (instance, tracer) => hookName => ({
	register: ({ name, type, fn }) => {
		const newFn = makeNewProfiledTapFn(hookName, tracer, {
			name,
			type,
			fn
		});
		return {
			// eslint-disable-line
			name,
			type,
			fn: newFn
		};
	}
});
```

I'm not sure whether this behavior of `interceptor.register` is intended or a bug.  If it is intended, `makeInterceptorFor` in `ProfilingPlugin` should be fixed to consider `context` property 