### PR TITLE
Removing unnecessary code in test case

### DIFF
--- a/lib/__tests__/SyncHook.js
+++ b/lib/__tests__/SyncHook.js
@@ -15,10 +15,6 @@ describe("SyncHook", () => {
 		const h2 = new SyncHook(["test", "arg2"]);
 		const h3 = new SyncHook(["test", "arg2", "arg3"]);
 
-		h0.call();
-		await h0.promise();
-		await new Promise(resolve => h0.callAsync(resolve));
-
 		const mock0 = jest.fn();
 		h0.tap("A", mock0);
 


### PR DESCRIPTION
I was going through the test cases of ```SyncHook``` class and realized few lines of code which weren't required in the ```expect```ations. Therefore I removed them. Please let me know if there is a different intention behind those lines of code. Thank you.