### PR TITLE
Add Prettier.js to format code

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+	printWidth: 80,
+	useTabs: true,
+	tabWidth: 2
+};

--- a/lib/AsyncParallelBailHook.js
+++ b/lib/AsyncParallelBailHook.js
@@ -29,7 +29,8 @@ class AsyncParallelBailHookCodeFactory extends HookCodeFactory {
 		code += this.callTapsParallel({
 			onError: (i, err, done, doneBreak) => {
 				let code = "";
-				code += `if(${i} < _results.length && ((_results.length = ${i + 1}), (_results[${i}] = { error: ${err} }), _checkDone())) {\n`;
+				code += `if(${i} < _results.length && ((_results.length = ${i +
+					1}), (_results[${i}] = { error: ${err} }), _checkDone())) {\n`;
 				code += doneBreak(true);
 				code += "} else {\n";
 				code += done();
@@ -38,7 +39,8 @@ class AsyncParallelBailHookCodeFactory extends HookCodeFactory {
 			},
 			onResult: (i, result, done, doneBreak) => {
 				let code = "";
-				code += `if(${i} < _results.length && (${result} !== undefined && (_results.length = ${i + 1}), (_results[${i}] = { result: ${result} }), _checkDone())) {\n`;
+				code += `if(${i} < _results.length && (${result} !== undefined && (_results.length = ${i +
+					1}), (_results[${i}] = { result: ${result} }), _checkDone())) {\n`;
 				code += doneBreak(true);
 				code += "} else {\n";
 				code += done();
@@ -47,13 +49,13 @@ class AsyncParallelBailHookCodeFactory extends HookCodeFactory {
 			},
 			onTap: (i, run, done, doneBreak) => {
 				let code = "";
-				if(i > 0) {
+				if (i > 0) {
 					code += `if(${i} >= _results.length) {\n`;
 					code += done();
 					code += "} else {\n";
 				}
 				code += run();
-				if(i > 0) code += "}\n";
+				if (i > 0) code += "}\n";
 				return code;
 			},
 			onDone
@@ -72,7 +74,7 @@ class AsyncParallelBailHook extends Hook {
 }
 
 Object.defineProperties(AsyncParallelBailHook.prototype, {
-	_call: {value: undefined, configurable: true, writable: true}
+	_call: { value: undefined, configurable: true, writable: true }
 });
 
 module.exports = AsyncParallelBailHook;

--- a/lib/AsyncParallelHook.js
+++ b/lib/AsyncParallelHook.js
@@ -26,7 +26,7 @@ class AsyncParallelHook extends Hook {
 }
 
 Object.defineProperties(AsyncParallelHook.prototype, {
-	_call: {value: undefined, configurable: true, writable: true}
+	_call: { value: undefined, configurable: true, writable: true }
 });
 
 module.exports = AsyncParallelHook;

--- a/lib/AsyncSeriesBailHook.js
+++ b/lib/AsyncSeriesBailHook.js
@@ -11,7 +11,10 @@ class AsyncSeriesBailHookCodeFactory extends HookCodeFactory {
 	content({ onError, onResult, onDone }) {
 		return this.callTapsSeries({
 			onError: (i, err, next, doneBreak) => onError(err) + doneBreak(true),
-			onResult: (i, result, next) => `if(${result} !== undefined) {\n${onResult(result)};\n} else {\n${next()}}\n`,
+			onResult: (i, result, next) =>
+				`if(${result} !== undefined) {\n${onResult(
+					result
+				)};\n} else {\n${next()}}\n`,
 			onDone
 		});
 	}
@@ -27,7 +30,7 @@ class AsyncSeriesBailHook extends Hook {
 }
 
 Object.defineProperties(AsyncSeriesBailHook.prototype, {
-	_call: {value: undefined, configurable: true, writable: true}
+	_call: { value: undefined, configurable: true, writable: true }
 });
 
 module.exports = AsyncSeriesBailHook;

--- a/lib/AsyncSeriesHook.js
+++ b/lib/AsyncSeriesHook.js
@@ -26,7 +26,7 @@ class AsyncSeriesHook extends Hook {
 }
 
 Object.defineProperties(AsyncSeriesHook.prototype, {
-	_call: {value: undefined, configurable: true, writable: true}
+	_call: { value: undefined, configurable: true, writable: true }
 });
 
 module.exports = AsyncSeriesHook;

--- a/lib/AsyncSeriesLoopHook.js
+++ b/lib/AsyncSeriesLoopHook.js
@@ -26,7 +26,7 @@ class AsyncSeriesLoopHook extends Hook {
 }
 
 Object.defineProperties(AsyncSeriesLoopHook.prototype, {
-	_call: {value: undefined, configurable: true, writable: true}
+	_call: { value: undefined, configurable: true, writable: true }
 });
 
 module.exports = AsyncSeriesLoopHook;

--- a/lib/AsyncSeriesWaterfallHook.js
+++ b/lib/AsyncSeriesWaterfallHook.js
@@ -29,7 +29,8 @@ const factory = new AsyncSeriesWaterfallHookCodeFactory();
 class AsyncSeriesWaterfallHook extends Hook {
 	constructor(args) {
 		super(args);
-		if(args.length < 1) throw new Error("Waterfall hooks must have at least one argument");
+		if (args.length < 1)
+			throw new Error("Waterfall hooks must have at least one argument");
 	}
 
 	compile(options) {
@@ -39,7 +40,7 @@ class AsyncSeriesWaterfallHook extends Hook {
 }
 
 Object.defineProperties(AsyncSeriesWaterfallHook.prototype, {
-	_call: {value: undefined, configurable: true, writable: true}
+	_call: { value: undefined, configurable: true, writable: true }
 });
 
 module.exports = AsyncSeriesWaterfallHook;

--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -6,7 +6,7 @@
 
 class Hook {
 	constructor(args) {
-		if(!Array.isArray(args)) args = [];
+		if (!Array.isArray(args)) args = [];
 		this._args = args;
 		this.taps = [];
 		this.interceptors = [];
@@ -30,62 +30,65 @@ class Hook {
 	}
 
 	tap(options, fn) {
-		if(typeof options === "string")
-			options = { name: options };
-		if(typeof options !== "object" || options === null)
-			throw new Error("Invalid arguments to tap(options: Object, fn: function)");
+		if (typeof options === "string") options = { name: options };
+		if (typeof options !== "object" || options === null)
+			throw new Error(
+				"Invalid arguments to tap(options: Object, fn: function)"
+			);
 		options = Object.assign({ type: "sync", fn: fn }, options);
-		if(typeof options.name !== "string" || options.name === "")
+		if (typeof options.name !== "string" || options.name === "")
 			throw new Error("Missing name for tap");
 		options = this._runRegisterInterceptors(options);
 		this._insert(options);
 	}
 
 	tapAsync(options, fn) {
-		if(typeof options === "string")
-			options = { name: options };
-		if(typeof options !== "object" || options === null)
-			throw new Error("Invalid arguments to tapAsync(options: Object, fn: function)");
+		if (typeof options === "string") options = { name: options };
+		if (typeof options !== "object" || options === null)
+			throw new Error(
+				"Invalid arguments to tapAsync(options: Object, fn: function)"
+			);
 		options = Object.assign({ type: "async", fn: fn }, options);
-		if(typeof options.name !== "string" || options.name === "")
+		if (typeof options.name !== "string" || options.name === "")
 			throw new Error("Missing name for tapAsync");
 		options = this._runRegisterInterceptors(options);
 		this._insert(options);
 	}
 
 	tapPromise(options, fn) {
-		if(typeof options === "string")
-			options = { name: options };
-		if(typeof options !== "object" || options === null)
-			throw new Error("Invalid arguments to tapPromise(options: Object, fn: function)");
+		if (typeof options === "string") options = { name: options };
+		if (typeof options !== "object" || options === null)
+			throw new Error(
+				"Invalid arguments to tapPromise(options: Object, fn: function)"
+			);
 		options = Object.assign({ type: "promise", fn: fn }, options);
-		if(typeof options.name !== "string" || options.name === "")
+		if (typeof options.name !== "string" || options.name === "")
 			throw new Error("Missing name for tapPromise");
 		options = this._runRegisterInterceptors(options);
 		this._insert(options);
 	}
 
 	_runRegisterInterceptors(options) {
-		for(const interceptor of this.interceptors) {
-			if(interceptor.register) {
+		for (const interceptor of this.interceptors) {
+			if (interceptor.register) {
 				const newOptions = interceptor.register(options);
-				if(newOptions !== undefined)
-					options = newOptions;
+				if (newOptions !== undefined) options = newOptions;
 			}
 		}
 		return options;
 	}
 
 	withOptions(options) {
-		const mergeOptions = opt => Object.assign({}, options, typeof opt === "string" ? { name: opt } : opt);
+		const mergeOptions = opt =>
+			Object.assign({}, options, typeof opt === "string" ? { name: opt } : opt);
 
 		// Prevent creating endless prototype chains
 		options = Object.assign({}, options, this._withOptions);
 		const base = this._withOptionsBase || this;
 		const newHook = Object.create(base);
 
-		newHook.tapAsync = (opt, fn) => base.tapAsync(mergeOptions(opt), fn),
-		newHook.tap = (opt, fn) => base.tap(mergeOptions(opt), fn);
+		(newHook.tapAsync = (opt, fn) => base.tapAsync(mergeOptions(opt), fn)),
+			(newHook.tap = (opt, fn) => base.tap(mergeOptions(opt), fn));
 		newHook.tapPromise = (opt, fn) => base.tapPromise(mergeOptions(opt), fn);
 		newHook._withOptions = options;
 		newHook._withOptionsBase = base;
@@ -99,8 +102,8 @@ class Hook {
 	intercept(interceptor) {
 		this._resetCompilation();
 		this.interceptors.push(Object.assign({}, interceptor));
-		if(interceptor.register) {
-			for(let i = 0; i < this.taps.length; i++)
+		if (interceptor.register) {
+			for (let i = 0; i < this.taps.length; i++)
 				this.taps[i] = interceptor.register(this.taps[i]);
 		}
 	}
@@ -114,30 +117,28 @@ class Hook {
 	_insert(item) {
 		this._resetCompilation();
 		let before;
-		if(typeof item.before === "string")
-			before = new Set([item.before]);
-		else if(Array.isArray(item.before)) {
+		if (typeof item.before === "string") before = new Set([item.before]);
+		else if (Array.isArray(item.before)) {
 			before = new Set(item.before);
 		}
 		let stage = 0;
-		if(typeof item.stage === "number")
-			stage = item.stage;
+		if (typeof item.stage === "number") stage = item.stage;
 		let i = this.taps.length;
-		while(i > 0) {
+		while (i > 0) {
 			i--;
 			const x = this.taps[i];
-			this.taps[i+1] = x;
+			this.taps[i + 1] = x;
 			const xStage = x.stage || 0;
-			if(before) {
-				if(before.has(x.name)) {
+			if (before) {
+				if (before.has(x.name)) {
 					before.delete(x.name);
 					continue;
 				}
-				if(before.size > 0) {
+				if (before.size > 0) {
 					continue;
 				}
 			}
-			if(xStage > stage) {
+			if (xStage > stage) {
 				continue;
 			}
 			i++;
@@ -155,9 +156,21 @@ function createCompileDelegate(name, type) {
 }
 
 Object.defineProperties(Hook.prototype, {
-	_call: {value: createCompileDelegate("call", "sync"), configurable: true, writable: true},
-	_promise: {value: createCompileDelegate("promise", "promise"), configurable: true, writable: true},
-	_callAsync: {value: createCompileDelegate("callAsync", "async"), configurable: true, writable: true}
-})
+	_call: {
+		value: createCompileDelegate("call", "sync"),
+		configurable: true,
+		writable: true
+	},
+	_promise: {
+		value: createCompileDelegate("promise", "promise"),
+		configurable: true,
+		writable: true
+	},
+	_callAsync: {
+		value: createCompileDelegate("callAsync", "async"),
+		configurable: true,
+		writable: true
+	}
+});
 
 module.exports = Hook;

--- a/lib/HookCodeFactory.js
+++ b/lib/HookCodeFactory.js
@@ -14,27 +14,37 @@ class HookCodeFactory {
 	create(options) {
 		this.init(options);
 		let fn;
-		switch(this.options.type) {
+		switch (this.options.type) {
 			case "sync":
-				fn = new Function(this.args(), "\"use strict\";\n" + this.header() + this.content({
-					onError: err => `throw ${err};\n`,
-					onResult: result => `return ${result};\n`,
-					onDone: () => "",
-					rethrowIfPossible: true
-				}));
+				fn = new Function(
+					this.args(),
+					'"use strict";\n' +
+						this.header() +
+						this.content({
+							onError: err => `throw ${err};\n`,
+							onResult: result => `return ${result};\n`,
+							onDone: () => "",
+							rethrowIfPossible: true
+						})
+				);
 				break;
 			case "async":
-				fn = new Function(this.args({
-					after: "_callback"
-				}), "\"use strict\";\n" + this.header() + this.content({
-					onError: err => `_callback(${err});\n`,
-					onResult: result => `_callback(null, ${result});\n`,
-					onDone: () => "_callback();\n"
-				}));
+				fn = new Function(
+					this.args({
+						after: "_callback"
+					}),
+					'"use strict";\n' +
+						this.header() +
+						this.content({
+							onError: err => `_callback(${err});\n`,
+							onResult: result => `_callback(null, ${result});\n`,
+							onDone: () => "_callback();\n"
+						})
+				);
 				break;
 			case "promise":
 				let code = "";
-				code += "\"use strict\";\n";
+				code += '"use strict";\n';
 				code += "return new Promise((_resolve, _reject) => {\n";
 				code += "var _sync = true;\n";
 				code += this.header();
@@ -78,19 +88,19 @@ class HookCodeFactory {
 
 	header() {
 		let code = "";
-		if(this.needContext()) {
+		if (this.needContext()) {
 			code += "var _context = {};\n";
 		} else {
 			code += "var _context;\n";
 		}
 		code += "var _x = this._x;\n";
-		if(this.options.interceptors.length > 0) {
+		if (this.options.interceptors.length > 0) {
 			code += "var _taps = this.taps;\n";
 			code += "var _interceptors = this.interceptors;\n";
 		}
-		for(let i = 0; i < this.options.interceptors.length; i++) {
+		for (let i = 0; i < this.options.interceptors.length; i++) {
 			const interceptor = this.options.interceptors[i];
-			if(interceptor.call) {
+			if (interceptor.call) {
 				code += `${this.getInterceptor(i)}.call(${this.args({
 					before: interceptor.context ? "_context" : undefined
 				})});\n`;
@@ -100,33 +110,34 @@ class HookCodeFactory {
 	}
 
 	needContext() {
-		for(const tap of this.options.taps)
-			if(tap.context) return true;
+		for (const tap of this.options.taps) if (tap.context) return true;
 		return false;
 	}
 
 	callTap(tapIndex, { onError, onResult, onDone, rethrowIfPossible }) {
 		let code = "";
 		let hasTapCached = false;
-		for(let i = 0; i < this.options.interceptors.length; i++) {
+		for (let i = 0; i < this.options.interceptors.length; i++) {
 			const interceptor = this.options.interceptors[i];
-			if(interceptor.tap) {
-				if(!hasTapCached) {
+			if (interceptor.tap) {
+				if (!hasTapCached) {
 					code += `var _tap${tapIndex} = ${this.getTap(tapIndex)};\n`;
 					hasTapCached = true;
 				}
-				code += `${this.getInterceptor(i)}.tap(${interceptor.context ? "_context, " : ""}_tap${tapIndex});\n`;
+				code += `${this.getInterceptor(i)}.tap(${
+					interceptor.context ? "_context, " : ""
+				}_tap${tapIndex});\n`;
 			}
 		}
 		code += `var _fn${tapIndex} = ${this.getTapFn(tapIndex)};\n`;
 		const tap = this.options.taps[tapIndex];
-		switch(tap.type) {
+		switch (tap.type) {
 			case "sync":
-				if(!rethrowIfPossible) {
+				if (!rethrowIfPossible) {
 					code += `var _hasError${tapIndex} = false;\n`;
 					code += "try {\n";
 				}
-				if(onResult) {
+				if (onResult) {
 					code += `var _result${tapIndex} = _fn${tapIndex}(${this.args({
 						before: tap.context ? "_context" : undefined
 					})});\n`;
@@ -135,36 +146,34 @@ class HookCodeFactory {
 						before: tap.context ? "_context" : undefined
 					})});\n`;
 				}
-				if(!rethrowIfPossible) {
+				if (!rethrowIfPossible) {
 					code += "} catch(_err) {\n";
 					code += `_hasError${tapIndex} = true;\n`;
 					code += onError("_err");
 					code += "}\n";
 					code += `if(!_hasError${tapIndex}) {\n`;
 				}
-				if(onResult) {
+				if (onResult) {
 					code += onResult(`_result${tapIndex}`);
 				}
-				if(onDone) {
+				if (onDone) {
 					code += onDone();
 				}
-				if(!rethrowIfPossible) {
+				if (!rethrowIfPossible) {
 					code += "}\n";
 				}
 				break;
 			case "async":
 				let cbCode = "";
-				if(onResult)
-					cbCode += `(_err${tapIndex}, _result${tapIndex}) => {\n`;
-				else
-					cbCode += `_err${tapIndex} => {\n`;
+				if (onResult) cbCode += `(_err${tapIndex}, _result${tapIndex}) => {\n`;
+				else cbCode += `_err${tapIndex} => {\n`;
 				cbCode += `if(_err${tapIndex}) {\n`;
 				cbCode += onError(`_err${tapIndex}`);
 				cbCode += "} else {\n";
-				if(onResult) {
+				if (onResult) {
 					cbCode += onResult(`_result${tapIndex}`);
 				}
-				if(onDone) {
+				if (onDone) {
 					cbCode += onDone();
 				}
 				cbCode += "}\n";
@@ -183,10 +192,10 @@ class HookCodeFactory {
 				code += `  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise${tapIndex} + ')');\n`;
 				code += `_promise${tapIndex}.then(_result${tapIndex} => {\n`;
 				code += `_hasResult${tapIndex} = true;\n`;
-				if(onResult) {
+				if (onResult) {
 					code += onResult(`_result${tapIndex}`);
 				}
-				if(onDone) {
+				if (onDone) {
 					code += onDone();
 				}
 				code += `}, _err${tapIndex} => {\n`;
@@ -199,47 +208,50 @@ class HookCodeFactory {
 	}
 
 	callTapsSeries({ onError, onResult, onDone, rethrowIfPossible }) {
-		if(this.options.taps.length === 0)
-			return onDone();
+		if (this.options.taps.length === 0) return onDone();
 		const firstAsync = this.options.taps.findIndex(t => t.type !== "sync");
 		const next = i => {
-			if(i >= this.options.taps.length) {
+			if (i >= this.options.taps.length) {
 				return onDone();
 			}
 			const done = () => next(i + 1);
-			const doneBreak = (skipDone) => {
-				if(skipDone) return "";
+			const doneBreak = skipDone => {
+				if (skipDone) return "";
 				return onDone();
-			}
+			};
 			return this.callTap(i, {
 				onError: error => onError(i, error, done, doneBreak),
-				onResult: onResult && ((result) => {
-					return onResult(i, result, done, doneBreak);
-				}),
-				onDone: !onResult && (() => {
-					return done();
-				}),
-				rethrowIfPossible: rethrowIfPossible && (firstAsync < 0 || i < firstAsync)
+				onResult:
+					onResult &&
+					(result => {
+						return onResult(i, result, done, doneBreak);
+					}),
+				onDone:
+					!onResult &&
+					(() => {
+						return done();
+					}),
+				rethrowIfPossible:
+					rethrowIfPossible && (firstAsync < 0 || i < firstAsync)
 			});
 		};
 		return next(0);
 	}
 
 	callTapsLooping({ onError, onDone, rethrowIfPossible }) {
-		if(this.options.taps.length === 0)
-			return onDone();
+		if (this.options.taps.length === 0) return onDone();
 		const syncOnly = this.options.taps.every(t => t.type === "sync");
 		let code = "";
-		if(!syncOnly) {
+		if (!syncOnly) {
 			code += "var _looper = () => {\n";
 			code += "var _loopAsync = false;\n";
 		}
 		code += "var _loop;\n";
 		code += "do {\n";
 		code += "_loop = false;\n";
-		for(let i = 0; i < this.options.interceptors.length; i++) {
+		for (let i = 0; i < this.options.interceptors.length; i++) {
 			const interceptor = this.options.interceptors[i];
-			if(interceptor.loop) {
+			if (interceptor.loop) {
 				code += `${this.getInterceptor(i)}.loop(${this.args({
 					before: interceptor.context ? "_context" : undefined
 				})});\n`;
@@ -251,25 +263,26 @@ class HookCodeFactory {
 				let code = "";
 				code += `if(${result} !== undefined) {\n`;
 				code += "_loop = true;\n";
-				if(!syncOnly)
-					code += "if(_loopAsync) _looper();\n";
+				if (!syncOnly) code += "if(_loopAsync) _looper();\n";
 				code += doneBreak(true);
 				code += `} else {\n`;
 				code += next();
 				code += `}\n`;
 				return code;
 			},
-			onDone: onDone && (() => {
-				let code = "";
-				code += "if(!_loop) {\n";
-				code += onDone();
-				code += "}\n";
-				return code;
-			}),
+			onDone:
+				onDone &&
+				(() => {
+					let code = "";
+					code += "if(!_loop) {\n";
+					code += onDone();
+					code += "}\n";
+					return code;
+				}),
 			rethrowIfPossible: rethrowIfPossible && syncOnly
-		})
+		});
 		code += "} while(_loop);\n";
-		if(!syncOnly) {
+		if (!syncOnly) {
 			code += "_loopAsync = true;\n";
 			code += "};\n";
 			code += "_looper();\n";
@@ -277,52 +290,69 @@ class HookCodeFactory {
 		return code;
 	}
 
-	callTapsParallel({ onError, onResult, onDone, rethrowIfPossible, onTap = (i, run) => run() }) {
-		if(this.options.taps.length <= 1) {
-			return this.callTapsSeries({ onError, onResult, onDone, rethrowIfPossible })
+	callTapsParallel({
+		onError,
+		onResult,
+		onDone,
+		rethrowIfPossible,
+		onTap = (i, run) => run()
+	}) {
+		if (this.options.taps.length <= 1) {
+			return this.callTapsSeries({
+				onError,
+				onResult,
+				onDone,
+				rethrowIfPossible
+			});
 		}
 		let code = "";
 		code += "do {\n";
 		code += `var _counter = ${this.options.taps.length};\n`;
-		if(onDone) {
+		if (onDone) {
 			code += "var _done = () => {\n";
 			code += onDone();
 			code += "};\n";
 		}
-		for(let i = 0; i < this.options.taps.length; i++) {
+		for (let i = 0; i < this.options.taps.length; i++) {
 			const done = () => {
-				if(onDone)
-					return "if(--_counter === 0) _done();\n";
-				else
-					return "--_counter;";
+				if (onDone) return "if(--_counter === 0) _done();\n";
+				else return "--_counter;";
 			};
-			const doneBreak = (skipDone) => {
-				if(skipDone || !onDone)
-					return "_counter = 0;\n";
-				else
-					return "_counter = 0;\n_done();\n";
-			}
+			const doneBreak = skipDone => {
+				if (skipDone || !onDone) return "_counter = 0;\n";
+				else return "_counter = 0;\n_done();\n";
+			};
 			code += "if(_counter <= 0) break;\n";
-			code += onTap(i, () => this.callTap(i, {
-				onError: error => {
-					let code = "";
-					code += "if(_counter > 0) {\n";
-					code += onError(i, error, done, doneBreak);
-					code += "}\n";
-					return code;
-				},
-				onResult: onResult && ((result) => {
-					let code = "";
-					code += "if(_counter > 0) {\n";
-					code += onResult(i, result, done, doneBreak);
-					code += "}\n";
-					return code;
-				}),
-				onDone: !onResult && (() => {
-					return done();
-				}),
-				rethrowIfPossible
-			}), done, doneBreak);
+			code += onTap(
+				i,
+				() =>
+					this.callTap(i, {
+						onError: error => {
+							let code = "";
+							code += "if(_counter > 0) {\n";
+							code += onError(i, error, done, doneBreak);
+							code += "}\n";
+							return code;
+						},
+						onResult:
+							onResult &&
+							(result => {
+								let code = "";
+								code += "if(_counter > 0) {\n";
+								code += onResult(i, result, done, doneBreak);
+								code += "}\n";
+								return code;
+							}),
+						onDone:
+							!onResult &&
+							(() => {
+								return done();
+							}),
+						rethrowIfPossible
+					}),
+				done,
+				doneBreak
+			);
 		}
 		code += "} while(false);\n";
 		return code;
@@ -330,9 +360,9 @@ class HookCodeFactory {
 
 	args({ before, after } = {}) {
 		let allArgs = this._args;
-		if(before) allArgs = [before].concat(allArgs);
-		if(after) allArgs = allArgs.concat(after);
-		if(allArgs.length === 0) {
+		if (before) allArgs = [before].concat(allArgs);
+		if (after) allArgs = allArgs.concat(after);
+		if (allArgs.length === 0) {
 			return "";
 		} else {
 			return allArgs.join(", ");

--- a/lib/HookMap.js
+++ b/lib/HookMap.js
@@ -17,12 +17,12 @@ class HookMap {
 
 	for(key) {
 		const hook = this.get(key);
-		if(hook !== undefined) {
+		if (hook !== undefined) {
 			return hook;
 		}
 		let newHook = this._factory(key);
 		const interceptors = this._interceptors;
-		for(let i = 0; i < interceptors.length; i++) {
+		for (let i = 0; i < interceptors.length; i++) {
 			newHook = interceptors[i].factory(key, newHook);
 		}
 		this._map.set(key, newHook);
@@ -30,9 +30,14 @@ class HookMap {
 	}
 
 	intercept(interceptor) {
-		this._interceptors.push(Object.assign({
-			factory: (key, hook) => hook
-		}, interceptor));
+		this._interceptors.push(
+			Object.assign(
+				{
+					factory: (key, hook) => hook
+				},
+				interceptor
+			)
+		);
 	}
 
 	tap(key, options, fn) {

--- a/lib/MultiHook.js
+++ b/lib/MultiHook.js
@@ -12,33 +12,32 @@ class MultiHook {
 	}
 
 	tap(options, fn) {
-		for(const hook of this.hooks) {
+		for (const hook of this.hooks) {
 			hook.tap(options, fn);
 		}
 	}
 
 	tapAsync(options, fn) {
-		for(const hook of this.hooks) {
+		for (const hook of this.hooks) {
 			hook.tapAsync(options, fn);
 		}
 	}
 
 	tapPromise(options, fn) {
-		for(const hook of this.hooks) {
+		for (const hook of this.hooks) {
 			hook.tapPromise(options, fn);
 		}
 	}
 
 	isUsed() {
-		for(const hook of this.hooks) {
-			if(hook.isUsed())
-				return true;
+		for (const hook of this.hooks) {
+			if (hook.isUsed()) return true;
 		}
 		return false;
 	}
 
 	intercept(interceptor) {
-		for(const hook of this.hooks) {
+		for (const hook of this.hooks) {
 			hook.intercept(interceptor);
 		}
 	}

--- a/lib/SyncBailHook.js
+++ b/lib/SyncBailHook.js
@@ -11,7 +11,10 @@ class SyncBailHookCodeFactory extends HookCodeFactory {
 	content({ onError, onResult, onDone, rethrowIfPossible }) {
 		return this.callTapsSeries({
 			onError: (i, err) => onError(err),
-			onResult: (i, result, next) => `if(${result} !== undefined) {\n${onResult(result)};\n} else {\n${next()}}\n`,
+			onResult: (i, result, next) =>
+				`if(${result} !== undefined) {\n${onResult(
+					result
+				)};\n} else {\n${next()}}\n`,
 			onDone,
 			rethrowIfPossible
 		});

--- a/lib/SyncWaterfallHook.js
+++ b/lib/SyncWaterfallHook.js
@@ -30,7 +30,8 @@ const factory = new SyncWaterfallHookCodeFactory();
 class SyncWaterfallHook extends Hook {
 	constructor(args) {
 		super(args);
-		if(args.length < 1) throw new Error("Waterfall hooks must have at least one argument");
+		if (args.length < 1)
+			throw new Error("Waterfall hooks must have at least one argument");
 	}
 
 	tapAsync() {

--- a/lib/Tapable.js
+++ b/lib/Tapable.js
@@ -9,35 +9,41 @@ const SyncBailHook = require("./SyncBailHook");
 
 function Tapable() {
 	this._pluginCompat = new SyncBailHook(["options"]);
-	this._pluginCompat.tap({
-		name: "Tapable camelCase",
-		stage: 100
-	}, options => {
-		options.names.add(options.name.replace(/[- ]([a-z])/g, (str, ch) => ch.toUpperCase()));
-	});
-	this._pluginCompat.tap({
-		name: "Tapable this.hooks",
-		stage: 200
-	}, options => {
-		let hook;
-		for(const name of options.names) {
-			hook = this.hooks[name];
-			if(hook !== undefined) {
-				break;
+	this._pluginCompat.tap(
+		{
+			name: "Tapable camelCase",
+			stage: 100
+		},
+		options => {
+			options.names.add(
+				options.name.replace(/[- ]([a-z])/g, (str, ch) => ch.toUpperCase())
+			);
+		}
+	);
+	this._pluginCompat.tap(
+		{
+			name: "Tapable this.hooks",
+			stage: 200
+		},
+		options => {
+			let hook;
+			for (const name of options.names) {
+				hook = this.hooks[name];
+				if (hook !== undefined) {
+					break;
+				}
+			}
+			if (hook !== undefined) {
+				const tapOpt = {
+					name: options.fn.name || "unnamed compat plugin",
+					stage: options.stage || 0
+				};
+				if (options.async) hook.tapAsync(tapOpt, options.fn);
+				else hook.tap(tapOpt, options.fn);
+				return true;
 			}
 		}
-		if(hook !== undefined) {
-			const tapOpt = {
-				name: options.fn.name || "unnamed compat plugin",
-				stage: options.stage || 0
-			};
-			if(options.async)
-				hook.tapAsync(tapOpt, options.fn);
-			else
-				hook.tap(tapOpt, options.fn);
-			return true;
-		}
-	});
+	);
 }
 module.exports = Tapable;
 
@@ -48,7 +54,7 @@ Tapable.addCompatLayer = function addCompatLayer(instance) {
 };
 
 Tapable.prototype.plugin = util.deprecate(function plugin(name, fn) {
-	if(Array.isArray(name)) {
+	if (Array.isArray(name)) {
 		name.forEach(function(name) {
 			this.plugin(name, fn);
 		}, this);
@@ -59,15 +65,17 @@ Tapable.prototype.plugin = util.deprecate(function plugin(name, fn) {
 		fn: fn,
 		names: new Set([name])
 	});
-	if(!result) {
-		throw new Error(`Plugin could not be registered at '${name}'. Hook was not found.\n` +
-			"BREAKING CHANGE: There need to exist a hook at 'this.hooks'. " +
-			"To create a compatibility layer for this hook, hook into 'this._pluginCompat'.");
+	if (!result) {
+		throw new Error(
+			`Plugin could not be registered at '${name}'. Hook was not found.\n` +
+				"BREAKING CHANGE: There need to exist a hook at 'this.hooks'. " +
+				"To create a compatibility layer for this hook, hook into 'this._pluginCompat'."
+		);
 	}
 }, "Tapable.plugin is deprecated. Use new API on `.hooks` instead");
 
 Tapable.prototype.apply = util.deprecate(function apply() {
-	for(var i = 0; i < arguments.length; i++) {
+	for (var i = 0; i < arguments.length; i++) {
 		arguments[i].apply(this);
 	}
 }, "Tapable.apply is deprecated. Call apply on the plugin directly instead");

--- a/lib/__tests__/AsyncParallelHooks.js
+++ b/lib/__tests__/AsyncParallelHooks.js
@@ -9,21 +9,29 @@ const AsyncParallelHook = require("../AsyncParallelHook");
 const AsyncParallelBailHook = require("../AsyncParallelBailHook");
 
 describe("AsyncParallelHook", () => {
-	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new AsyncParallelHook(args));
+	it(
+		"should have to correct behavior",
+		async () => {
+			const tester = new HookTester(args => new AsyncParallelHook(args));
 
-		const result = await tester.run();
+			const result = await tester.run();
 
-		expect(result).toMatchSnapshot();
-	}, 15000)
-})
+			expect(result).toMatchSnapshot();
+		},
+		15000
+	);
+});
 
 describe("AsyncParallelBailHook", () => {
-	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new AsyncParallelBailHook(args));
+	it(
+		"should have to correct behavior",
+		async () => {
+			const tester = new HookTester(args => new AsyncParallelBailHook(args));
 
-		const result = await tester.run();
+			const result = await tester.run();
 
-		expect(result).toMatchSnapshot();
-	}, 15000)
-})
+			expect(result).toMatchSnapshot();
+		},
+		15000
+	);
+});

--- a/lib/__tests__/AsyncSeriesHooks.js
+++ b/lib/__tests__/AsyncSeriesHooks.js
@@ -12,40 +12,40 @@ const AsyncSeriesLoopHook = require("../AsyncSeriesLoopHook");
 
 describe("AsyncSeriesHook", () => {
 	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new AsyncSeriesHook(args));
+		const tester = new HookTester(args => new AsyncSeriesHook(args));
 
 		const result = await tester.run();
 
 		expect(result).toMatchSnapshot();
-	})
-})
+	});
+});
 
 describe("AsyncSeriesBailHook", () => {
 	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new AsyncSeriesBailHook(args));
+		const tester = new HookTester(args => new AsyncSeriesBailHook(args));
 
 		const result = await tester.run();
 
 		expect(result).toMatchSnapshot();
-	})
-})
+	});
+});
 
 describe("AsyncSeriesWaterfallHook", () => {
 	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new AsyncSeriesWaterfallHook(args));
+		const tester = new HookTester(args => new AsyncSeriesWaterfallHook(args));
 
 		const result = await tester.run();
 
 		expect(result).toMatchSnapshot();
-	})
-})
+	});
+});
 
 describe("AsyncSeriesLoopHook", () => {
 	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new AsyncSeriesLoopHook(args));
+		const tester = new HookTester(args => new AsyncSeriesLoopHook(args));
 
 		const result = await tester.runForLoop();
 
 		expect(result).toMatchSnapshot();
-	})
-})
+	});
+});

--- a/lib/__tests__/Hook.js
+++ b/lib/__tests__/Hook.js
@@ -12,41 +12,56 @@ describe("Hook", () => {
 
 		const calls = [];
 		hook.tap("A", () => calls.push("A"));
-		hook.tap({
-			name: "B",
-			before: "A"
-		}, () => calls.push("B"));
+		hook.tap(
+			{
+				name: "B",
+				before: "A"
+			},
+			() => calls.push("B")
+		);
 
 		calls.length = 0;
 		hook.call();
 		expect(calls).toEqual(["B", "A"]);
 
-		hook.tap({
-			name: "C",
-			before: ["A", "B"]
-		}, () => calls.push("C"));
+		hook.tap(
+			{
+				name: "C",
+				before: ["A", "B"]
+			},
+			() => calls.push("C")
+		);
 
 		calls.length = 0;
 		hook.call();
 		expect(calls).toEqual(["C", "B", "A"]);
 
-		hook.tap({
-			name: "D",
-			before: "B"
-		}, () => calls.push("D"));
+		hook.tap(
+			{
+				name: "D",
+				before: "B"
+			},
+			() => calls.push("D")
+		);
 
 		calls.length = 0;
 		hook.call();
 		expect(calls).toEqual(["C", "D", "B", "A"]);
 
-		hook.tap({
-			name: "E",
-			stage: -5
-		}, () => calls.push("E"));
-		hook.tap({
-			name: "F",
-			stage: -3
-		}, () => calls.push("F"));
+		hook.tap(
+			{
+				name: "E",
+				stage: -5
+			},
+			() => calls.push("E")
+		);
+		hook.tap(
+			{
+				name: "F",
+				stage: -3
+			},
+			() => calls.push("F")
+		);
 
 		calls.length = 0;
 		hook.call();

--- a/lib/__tests__/HookCodeFactory.js
+++ b/lib/__tests__/HookCodeFactory.js
@@ -6,7 +6,7 @@
 
 const HookCodeFactory = require("../HookCodeFactory");
 
-const expectNoSyntaxError = (code) => {
+const expectNoSyntaxError = code => {
 	new Function("a, b, c", code);
 };
 
@@ -66,11 +66,11 @@ describe("HookCodeFactory", () => {
 					},
 					{
 						call: () => {}
-					},
+					}
 				]
 			}
-		}
-		for(const configurationName in factoryConfigurations) {
+		};
+		for (const configurationName in factoryConfigurations) {
 			describe(`(${configurationName})`, () => {
 				let factory;
 				beforeEach(() => {
@@ -130,7 +130,7 @@ describe("HookCodeFactory", () => {
 	});
 	describe("taps", () => {
 		const factoryConfigurations = {
-			"none": {
+			none: {
 				args: ["a", "b", "c"],
 				taps: [],
 				interceptors: []
@@ -177,7 +177,7 @@ describe("HookCodeFactory", () => {
 				],
 				interceptors: []
 			},
-			"mixed": {
+			mixed: {
 				args: ["a", "b", "c"],
 				taps: [
 					{
@@ -192,7 +192,7 @@ describe("HookCodeFactory", () => {
 				],
 				interceptors: []
 			},
-			"mixed2": {
+			mixed2: {
 				args: ["a", "b", "c"],
 				taps: [
 					{
@@ -203,12 +203,12 @@ describe("HookCodeFactory", () => {
 					},
 					{
 						type: "sync"
-					},
+					}
 				],
 				interceptors: []
-			},
-		}
-		for(const configurationName in factoryConfigurations) {
+			}
+		};
+		for (const configurationName in factoryConfigurations) {
 			describe(`(${configurationName})`, () => {
 				let factory;
 				beforeEach(() => {
@@ -218,7 +218,8 @@ describe("HookCodeFactory", () => {
 				it("callTapsSeries", () => {
 					const code = factory.callTapsSeries({
 						onError: (i, err) => `onError(${i}, ${err});\n`,
-						onResult: (i, result, next, doneBreak) => `onResult(${i}, ${result}, () => {\n${next()}}, () => {\n${doneBreak()}});\n`,
+						onResult: (i, result, next, doneBreak) =>
+							`onResult(${i}, ${result}, () => {\n${next()}}, () => {\n${doneBreak()}});\n`,
 						onDone: () => "onDone();\n",
 						rethrowIfPossible: true
 					});
@@ -228,7 +229,8 @@ describe("HookCodeFactory", () => {
 				it("callTapsParallel", () => {
 					const code = factory.callTapsParallel({
 						onError: (i, err) => `onError(${i}, ${err});\n`,
-						onResult: (i, result, done, doneBreak) => `onResult(${i}, ${result}, () => {\n${done()}}, () => {\n${doneBreak()}});\n`,
+						onResult: (i, result, done, doneBreak) =>
+							`onResult(${i}, ${result}, () => {\n${done()}}, () => {\n${doneBreak()}});\n`,
 						onDone: () => "onDone();\n",
 						rethrowIfPossible: true
 					});

--- a/lib/__tests__/HookTester.js
+++ b/lib/__tests__/HookTester.js
@@ -25,18 +25,14 @@ class HookTester {
 			intercept: {}
 		};
 
-		if(syncOnly) {
-
+		if (syncOnly) {
 			await this.runSync(result.sync, "call");
-
 		} else {
-
 			await this.runAsync(result.async, "callAsync");
 			await this.runAsync(result.async, "promise");
 
 			await this.runIntercept(result.intercept, "callAsync");
 			await this.runIntercept(result.intercept, "promise");
-
 		}
 
 		await this.runSync(result.sync, "callAsync");
@@ -51,15 +47,11 @@ class HookTester {
 			async: {}
 		};
 
-		if(syncOnly) {
-
+		if (syncOnly) {
 			await this.runForLoopSync(result.sync, "call");
-
 		} else {
-
 			await this.runForLoopAsync(result.async, "callAsync");
 			await this.runForLoopAsync(result.async, "promise");
-
 		}
 
 		await this.runForLoopSync(result.sync, "callAsync");
@@ -72,80 +64,98 @@ class HookTester {
 		{
 			const hook = this.createHook([], `${method}BrokenPromise`);
 			hook.tapPromise("promise", () => "this is not a promise");
-			result[`${method}BrokenPromise`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}BrokenPromise`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 		{
 			const hook = this.createHook([], `${method}SinglePromise`);
 			hook.tapPromise("promise", () => {
-				result[`${method}SinglePromiseCalled`] = (result[`${method}SinglePromiseCalled`] || 0) + 1;
-				if(result[`${method}SinglePromiseCalled`] < 42)
+				result[`${method}SinglePromiseCalled`] =
+					(result[`${method}SinglePromiseCalled`] || 0) + 1;
+				if (result[`${method}SinglePromiseCalled`] < 42)
 					return Promise.resolve().then(() => true);
 				return Promise.resolve().then(() => {});
 			});
-			result[`${method}SinglePromise`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}SinglePromise`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${method}MultiplePromise`);
 			hook.tapPromise("promise1", () => {
-				result[`${method}MultiplePromiseCalled1`] = (result[`${method}MultiplePromiseCalled1`] || 0) + 1;
-				if(result[`${method}MultiplePromiseCalled1`] < 42)
+				result[`${method}MultiplePromiseCalled1`] =
+					(result[`${method}MultiplePromiseCalled1`] || 0) + 1;
+				if (result[`${method}MultiplePromiseCalled1`] < 42)
 					return Promise.resolve().then(() => true);
 				return Promise.resolve().then(() => {});
 			});
 			hook.tapPromise("promise2", () => {
-				result[`${method}MultiplePromiseCalled2`] = (result[`${method}MultiplePromiseCalled2`] || 0) + 1;
-				if(result[`${method}MultiplePromiseCalled2`] < 42)
+				result[`${method}MultiplePromiseCalled2`] =
+					(result[`${method}MultiplePromiseCalled2`] || 0) + 1;
+				if (result[`${method}MultiplePromiseCalled2`] < 42)
 					return Promise.resolve().then(() => true);
 				return Promise.resolve().then(() => {});
 			});
-			result[`${method}MultiplePromise`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}MultiplePromise`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${method}SingleAsync`);
-			hook.tapAsync("async", (callback) => {
-				result[`${method}SingleAsyncCalled`] = (result[`${method}SingleAsyncCalled`] || 0) + 1;
-				if(result[`${method}SingleAsyncCalled`] < 42)
+			hook.tapAsync("async", callback => {
+				result[`${method}SingleAsyncCalled`] =
+					(result[`${method}SingleAsyncCalled`] || 0) + 1;
+				if (result[`${method}SingleAsyncCalled`] < 42)
 					return Promise.resolve().then(() => callback(null, true));
 				return Promise.resolve().then(() => callback());
 			});
-			result[`${method}SingleAsync`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}SingleAsync`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${method}MultipleAsync`);
-			hook.tapAsync("async1", (callback) => {
-				result[`${method}MultipleAsyncCalled1`] = (result[`${method}MultipleAsyncCalled1`] || 0) + 1;
-				if(result[`${method}MultipleAsyncCalled1`] < 42)
+			hook.tapAsync("async1", callback => {
+				result[`${method}MultipleAsyncCalled1`] =
+					(result[`${method}MultipleAsyncCalled1`] || 0) + 1;
+				if (result[`${method}MultipleAsyncCalled1`] < 42)
 					return Promise.resolve().then(() => callback(null, true));
 				return Promise.resolve().then(() => callback());
 			});
-			hook.tapAsync("async2", (callback) => {
-				result[`${method}MultipleAsyncCalled2`] = (result[`${method}MultipleAsyncCalled2`] || 0) + 1;
-				if(result[`${method}MultipleAsyncCalled2`] < 42)
+			hook.tapAsync("async2", callback => {
+				result[`${method}MultipleAsyncCalled2`] =
+					(result[`${method}MultipleAsyncCalled2`] || 0) + 1;
+				if (result[`${method}MultipleAsyncCalled2`] < 42)
 					return Promise.resolve().then(() => callback(null, true));
 				return Promise.resolve().then(() => callback());
 			});
-			result[`${method}MultipleAsync`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}MultipleAsync`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${method}Mixed`);
-			hook.tapAsync("async1", (callback) => {
-				result[`${method}MixedCalled1`] = (result[`${method}MixedCalled1`] || 0) + 1;
-				if(result[`${method}MixedCalled1`] < 42)
+			hook.tapAsync("async1", callback => {
+				result[`${method}MixedCalled1`] =
+					(result[`${method}MixedCalled1`] || 0) + 1;
+				if (result[`${method}MixedCalled1`] < 42)
 					return Promise.resolve().then(() => callback(null, true));
 				return Promise.resolve().then(() => callback());
 			});
 			hook.tap("sync2", () => {
-				result[`${method}MixedCalled2`] = (result[`${method}MixedCalled2`] || 0) + 1;
-				if(result[`${method}MixedCalled2`] < 42)
-					return true;
+				result[`${method}MixedCalled2`] =
+					(result[`${method}MixedCalled2`] || 0) + 1;
+				if (result[`${method}MixedCalled2`] < 42) return true;
 			});
 			hook.tapPromise("promise3", () => {
-				result[`${method}MixedCalled3`] = (result[`${method}MixedCalled3`] || 0) + 1;
-				if(result[`${method}MixedCalled3`] < 42)
+				result[`${method}MixedCalled3`] =
+					(result[`${method}MixedCalled3`] || 0) + 1;
+				if (result[`${method}MixedCalled3`] < 42)
 					return Promise.resolve().then(() => true);
 				return Promise.resolve().then(() => {});
 			});
@@ -161,54 +171,67 @@ class HookTester {
 
 		{
 			const hook = this.createHook(["arg"], `${method}NoneWithArg`);
-			result[`${method}NoneWithArg`] = await this.gainResult(cb => hook[method](42, cb));
+			result[`${method}NoneWithArg`] = await this.gainResult(cb =>
+				hook[method](42, cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${method}SingleSync`);
 			hook.tap("sync", () => {
-				result[`${method}SingleSyncCalled`] = (result[`${method}SingleSyncCalled`] || 0) + 1;
-				if(result[`${method}SingleSyncCalled`] < 42)
-					return true;
+				result[`${method}SingleSyncCalled`] =
+					(result[`${method}SingleSyncCalled`] || 0) + 1;
+				if (result[`${method}SingleSyncCalled`] < 42) return true;
 			});
-			result[`${method}SingleSync`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}SingleSync`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${method}MultipleSync`);
 			hook.tap("sync1", () => {
-				result[`${method}MultipleSyncCalled1`] = (result[`${method}MultipleSyncCalled1`] || 0) + 1;
-				if(result[`${method}MultipleSyncCalled1`] < 42)
-					return true;
+				result[`${method}MultipleSyncCalled1`] =
+					(result[`${method}MultipleSyncCalled1`] || 0) + 1;
+				if (result[`${method}MultipleSyncCalled1`] < 42) return true;
 			});
 			hook.tap("sync2", () => {
-				result[`${method}MultipleSyncCalled2`] = (result[`${method}MultipleSyncCalled2`] || 0) + 1;
-				if(result[`${method}MultipleSyncCalled2`] < 42)
-					return true;
+				result[`${method}MultipleSyncCalled2`] =
+					(result[`${method}MultipleSyncCalled2`] || 0) + 1;
+				if (result[`${method}MultipleSyncCalled2`] < 42) return true;
 			});
-			result[`${method}MultipleSync`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}MultipleSync`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${method}InterceptedSync`);
 			hook.tap("sync1", () => {
-				result[`${method}InterceptedSyncCalled1`] = (result[`${method}InterceptedSyncCalled1`] || 0) + 1;
-				if(result[`${method}InterceptedSyncCalled1`] < 42)
-					return true;
+				result[`${method}InterceptedSyncCalled1`] =
+					(result[`${method}InterceptedSyncCalled1`] || 0) + 1;
+				if (result[`${method}InterceptedSyncCalled1`] < 42) return true;
 			});
 			hook.tap("sync2", () => {
-				result[`${method}InterceptedSyncCalled2`] = (result[`${method}InterceptedSyncCalled2`] || 0) + 1;
-				if(result[`${method}InterceptedSyncCalled2`] < 42)
-					return true;
+				result[`${method}InterceptedSyncCalled2`] =
+					(result[`${method}InterceptedSyncCalled2`] || 0) + 1;
+				if (result[`${method}InterceptedSyncCalled2`] < 42) return true;
 			});
 			hook.intercept({
-				call: (a) => result[`${method}InterceptedSyncCalledCall`] = (result[`${method}InterceptedSyncCalledCall`] || 0) + 1,
-				loop: (a) => result[`${method}InterceptedSyncCalledLoop`] = (result[`${method}InterceptedSyncCalledLoop`] || 0) + 1,
-				tap: (tap) => {
-					result[`${method}InterceptedSyncCalledTap`] = (result[`${method}InterceptedSyncCalledTap`] || 0) + 1
-				},
-			})
-			result[`${method}InterceptedSync`] = await this.gainResult(cb => hook[method](cb));
+				call: a =>
+					(result[`${method}InterceptedSyncCalledCall`] =
+						(result[`${method}InterceptedSyncCalledCall`] || 0) + 1),
+				loop: a =>
+					(result[`${method}InterceptedSyncCalledLoop`] =
+						(result[`${method}InterceptedSyncCalledLoop`] || 0) + 1),
+				tap: tap => {
+					result[`${method}InterceptedSyncCalledTap`] =
+						(result[`${method}InterceptedSyncCalledTap`] || 0) + 1;
+				}
+			});
+			result[`${method}InterceptedSync`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 	}
 
@@ -220,7 +243,9 @@ class HookTester {
 
 		{
 			const hook = this.createHook(["arg"], `${method}NoneWithArg`);
-			result[`${method}NoneWithArg`] = await this.gainResult(cb => hook[method](42, cb));
+			result[`${method}NoneWithArg`] = await this.gainResult(cb =>
+				hook[method](42, cb)
+			);
 		}
 
 		{
@@ -229,16 +254,20 @@ class HookTester {
 				result[`${method}SingleSyncCalled`] = true;
 				return 42;
 			});
-			result[`${method}SingleSync`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}SingleSync`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook(["myArg"], `${method}SingleSyncWithArg`);
-			hook.tap("sync", (nr) => {
+			hook.tap("sync", nr => {
 				result[`${method}SingleSyncWithArgCalled`] = nr;
 				return nr;
 			});
-			result[`${method}SingleSyncWithArg`] = await this.gainResult(cb => hook[method](42, cb));
+			result[`${method}SingleSyncWithArg`] = await this.gainResult(cb =>
+				hook[method](42, cb)
+			);
 		}
 
 		{
@@ -251,59 +280,81 @@ class HookTester {
 				result[`${method}MultipleSyncCalled2`] = true;
 				return 43;
 			});
-			result[`${method}MultipleSync`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}MultipleSync`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook(["a"], `${method}MultipleSyncWithArg`);
-			hook.tap("sync1", (a) => {
+			hook.tap("sync1", a => {
 				result[`${method}MultipleSyncWithArgCalled1`] = a;
 				return 42 + a;
 			});
-			hook.tap("sync2", (a) => {
+			hook.tap("sync2", a => {
 				result[`${method}MultipleSyncWithArgCalled2`] = a;
 				return 43 + a;
 			});
-			result[`${method}MultipleSyncWithArg`] = await this.gainResult(cb => hook[method](42, cb));
+			result[`${method}MultipleSyncWithArg`] = await this.gainResult(cb =>
+				hook[method](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["a"], `${method}MultipleSyncWithArgNoReturn`);
-			hook.tap("sync1", (a) => {
+			const hook = this.createHook(
+				["a"],
+				`${method}MultipleSyncWithArgNoReturn`
+			);
+			hook.tap("sync1", a => {
 				result[`${method}MultipleSyncWithArgNoReturnCalled1`] = a;
 			});
-			hook.tap("sync2", (a) => {
+			hook.tap("sync2", a => {
 				result[`${method}MultipleSyncWithArgNoReturnCalled2`] = a;
 			});
-			result[`${method}MultipleSyncWithArgNoReturn`] = await this.gainResult(cb => hook[method](42, cb));
+			result[`${method}MultipleSyncWithArgNoReturn`] = await this.gainResult(
+				cb => hook[method](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["a"], `${method}MultipleSyncWithArgFirstReturn`);
-			hook.tap("sync1", (a) => {
+			const hook = this.createHook(
+				["a"],
+				`${method}MultipleSyncWithArgFirstReturn`
+			);
+			hook.tap("sync1", a => {
 				result[`${method}MultipleSyncWithArgFirstReturnCalled1`] = a;
 				return 42 + a;
 			});
-			hook.tap("sync2", (a) => {
+			hook.tap("sync2", a => {
 				result[`${method}MultipleSyncWithArgFirstReturnCalled2`] = a;
 			});
-			result[`${method}MultipleSyncWithArgFirstReturn`] = await this.gainResult(cb => hook[method](42, cb));
+			result[`${method}MultipleSyncWithArgFirstReturn`] = await this.gainResult(
+				cb => hook[method](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["a"], `${method}MultipleSyncWithArgLastReturn`);
-			hook.tap("sync1", (a) => {
+			const hook = this.createHook(
+				["a"],
+				`${method}MultipleSyncWithArgLastReturn`
+			);
+			hook.tap("sync1", a => {
 				result[`${method}MultipleSyncWithArgLastReturnCalled1`] = a;
 			});
-			hook.tap("sync2", (a) => {
+			hook.tap("sync2", a => {
 				result[`${method}MultipleSyncWithArgLastReturnCalled2`] = a;
 				return 43 + a;
 			});
-			result[`${method}MultipleSyncWithArgLastReturn`] = await this.gainResult(cb => hook[method](42, cb));
+			result[`${method}MultipleSyncWithArgLastReturn`] = await this.gainResult(
+				cb => hook[method](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["a", "b", "c"], `${method}MultipleSyncWithArgs`);
+			const hook = this.createHook(
+				["a", "b", "c"],
+				`${method}MultipleSyncWithArgs`
+			);
 			hook.tap("sync1", (a, b, c) => {
 				result[`${method}MultipleSyncWithArgsCalled1`] = [a, b, c];
 				return a + b + c;
@@ -312,7 +363,9 @@ class HookTester {
 				result[`${method}MultipleSyncWithArgsCalled2`] = [a, b, c];
 				return a + b + c + 1;
 			});
-			result[`${method}MultipleSyncWithArgs`] = await this.gainResult(cb => hook[method](42, 43, 44, cb));
+			result[`${method}MultipleSyncWithArgs`] = await this.gainResult(cb =>
+				hook[method](42, 43, 44, cb)
+			);
 		}
 
 		{
@@ -322,12 +375,14 @@ class HookTester {
 			});
 			hook.tap("sync2", () => {
 				result[`${method}MultipleSyncErrorCalled2`] = true;
-				throw new Error("Error in sync2")
+				throw new Error("Error in sync2");
 			});
 			hook.tap("sync3", () => {
 				result[`${method}MultipleSyncErrorCalled3`] = true;
 			});
-			result[`${method}MultipleSyncError`] = await this.gainResult(cb => hook[method](cb));
+			result[`${method}MultipleSyncError`] = await this.gainResult(cb =>
+				hook[method](cb)
+			);
 		}
 
 		{
@@ -336,34 +391,42 @@ class HookTester {
 				call: (a, b, c) => {
 					result[`${method}InterceptedCall1`] = [a, b, c];
 				},
-				tap: (tap) => {
-					result[`${method}InterceptedTap1`] = Object.assign({}, tap, { fn: tap.fn.length });
+				tap: tap => {
+					result[`${method}InterceptedTap1`] = Object.assign({}, tap, {
+						fn: tap.fn.length
+					});
 				}
 			});
 			hook.intercept({
 				call: (a, b, c) => {
 					result[`${method}InterceptedCall2`] = [a, b, c];
 				},
-				tap: (tap) => {
-					if(!result[`${method}InterceptedTap2`])
-						result[`${method}InterceptedTap2`] = Object.assign({}, tap, { fn: tap.fn.length });
+				tap: tap => {
+					if (!result[`${method}InterceptedTap2`])
+						result[`${method}InterceptedTap2`] = Object.assign({}, tap, {
+							fn: tap.fn.length
+						});
 				}
 			});
 			hook.tap("sync1", (a, b, c) => a + b + c);
 			hook.tap("sync2", (a, b) => a + b + 1);
-			result[`${method}Intercepted`] = await this.gainResult((cb) => hook[method](1, 2, 3, cb));
+			result[`${method}Intercepted`] = await this.gainResult(cb =>
+				hook[method](1, 2, 3, cb)
+			);
 		}
 	}
 
 	async runAsync(result, type) {
 		{
 			const hook = this.createHook([], `${type}None`);
-			result[`${type}None`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}None`] = await this.gainResult(cb => hook[type](cb));
 		}
 
 		{
 			const hook = this.createHook(["arg"], `${type}NoneWithArg`);
-			result[`${type}NoneWithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}NoneWithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -372,7 +435,7 @@ class HookTester {
 				result[`${type}SingleSyncCalled1`] = true;
 				return 42;
 			});
-			result[`${type}SingleSync`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}SingleSync`] = await this.gainResult(cb => hook[type](cb));
 		}
 
 		{
@@ -381,7 +444,9 @@ class HookTester {
 				result[`${type}SingleSyncWithArgCalled1`] = arg;
 				return arg + 1;
 			});
-			result[`${type}SingleSyncWithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}SingleSyncWithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -389,7 +454,9 @@ class HookTester {
 			hook.tap("sync", arg => {
 				result[`${type}SingleSyncWithArgNoReturnCalled1`] = arg;
 			});
-			result[`${type}SingleSyncWithArgNoReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}SingleSyncWithArgNoReturn`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -402,7 +469,9 @@ class HookTester {
 				result[`${type}MultipleSyncCalled2`] = true;
 				return 43;
 			});
-			result[`${type}MultipleSync`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultipleSync`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
@@ -414,7 +483,9 @@ class HookTester {
 				result[`${type}MultipleSyncLastReturnCalled2`] = true;
 				return 43;
 			});
-			result[`${type}MultipleSyncLastReturn`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultipleSyncLastReturn`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
@@ -425,7 +496,9 @@ class HookTester {
 			hook.tap("sync2", () => {
 				result[`${type}MultipleSyncNoReturnCalled2`] = true;
 			});
-			result[`${type}MultipleSyncNoReturn`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultipleSyncNoReturn`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
@@ -438,22 +511,32 @@ class HookTester {
 				result[`${type}MultipleSyncWithArgCalled2`] = arg;
 				return arg + 2;
 			});
-			result[`${type}MultipleSyncWithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleSyncWithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["arg"], `${type}MultipleSyncWithArgNoReturn`);
+			const hook = this.createHook(
+				["arg"],
+				`${type}MultipleSyncWithArgNoReturn`
+			);
 			hook.tap("sync1", arg => {
 				result[`${type}MultipleSyncWithArgNoReturnCalled1`] = arg;
 			});
 			hook.tap("sync2", arg => {
 				result[`${type}MultipleSyncWithArgNoReturnCalled2`] = arg;
 			});
-			result[`${type}MultipleSyncWithArgNoReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleSyncWithArgNoReturn`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["arg"], `${type}MultipleSyncWithArgLastReturn`);
+			const hook = this.createHook(
+				["arg"],
+				`${type}MultipleSyncWithArgLastReturn`
+			);
 			hook.tap("sync1", arg => {
 				result[`${type}MultipleSyncWithArgLastReturnCalled1`] = arg;
 			});
@@ -461,11 +544,16 @@ class HookTester {
 				result[`${type}MultipleSyncWithArgLastReturnCalled2`] = arg;
 				return arg + 2;
 			});
-			result[`${type}MultipleSyncWithArgLastReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleSyncWithArgLastReturn`] = await this.gainResult(
+				cb => hook[type](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["arg"], `${type}MultipleSyncWithArgFirstReturn`);
+			const hook = this.createHook(
+				["arg"],
+				`${type}MultipleSyncWithArgFirstReturn`
+			);
 			hook.tap("sync1", arg => {
 				result[`${type}MultipleSyncWithArgFirstReturnCalled1`] = arg;
 				return arg + 1;
@@ -473,7 +561,9 @@ class HookTester {
 			hook.tap("sync2", arg => {
 				result[`${type}MultipleSyncWithArgFirstReturnCalled2`] = arg;
 			});
-			result[`${type}MultipleSyncWithArgFirstReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleSyncWithArgFirstReturn`] = await this.gainResult(
+				cb => hook[type](42, cb)
+			);
 		}
 
 		{
@@ -482,7 +572,9 @@ class HookTester {
 				result[`${type}SingleAsyncWithArgCalled1`] = arg;
 				callback(null, arg);
 			});
-			result[`${type}SingleAsyncWithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}SingleAsyncWithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -495,11 +587,16 @@ class HookTester {
 				result[`${type}MultipleAsyncWithArgCalled2`] = arg;
 				callback(null, arg + 2);
 			});
-			result[`${type}MultipleAsyncWithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleAsyncWithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["x"], `${type}MultipleAsyncWithArgNoReturn`);
+			const hook = this.createHook(
+				["x"],
+				`${type}MultipleAsyncWithArgNoReturn`
+			);
 			hook.tapAsync("async1", (arg, callback) => {
 				result[`${type}MultipleAsyncWithArgNoReturnCalled1`] = arg;
 				callback();
@@ -508,11 +605,16 @@ class HookTester {
 				result[`${type}MultipleAsyncWithArgNoReturnCalled2`] = arg;
 				callback();
 			});
-			result[`${type}MultipleAsyncWithArgNoReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleAsyncWithArgNoReturn`] = await this.gainResult(
+				cb => hook[type](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["x"], `${type}MultipleAsyncWithArgFirstReturn`);
+			const hook = this.createHook(
+				["x"],
+				`${type}MultipleAsyncWithArgFirstReturn`
+			);
 			hook.tapAsync("async1", (arg, callback) => {
 				result[`${type}MultipleAsyncWithArgFirstReturnCalled1`] = arg;
 				callback(null, arg + 1);
@@ -521,11 +623,16 @@ class HookTester {
 				result[`${type}MultipleAsyncWithArgFirstReturnCalled2`] = arg;
 				callback();
 			});
-			result[`${type}MultipleAsyncWithArgFirstReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleAsyncWithArgFirstReturn`] = await this.gainResult(
+				cb => hook[type](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["x"], `${type}MultipleAsyncWithArgLastReturn`);
+			const hook = this.createHook(
+				["x"],
+				`${type}MultipleAsyncWithArgLastReturn`
+			);
 			hook.tapAsync("async1", (arg, callback) => {
 				result[`${type}MultipleAsyncWithArgLastReturnCalled1`] = arg;
 				callback();
@@ -534,7 +641,9 @@ class HookTester {
 				result[`${type}MultipleAsyncWithArgLastReturnCalled2`] = arg;
 				callback(null, arg + 2);
 			});
-			result[`${type}MultipleAsyncWithArgLastReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleAsyncWithArgLastReturn`] = await this.gainResult(
+				cb => hook[type](42, cb)
+			);
 		}
 
 		{
@@ -543,7 +652,9 @@ class HookTester {
 				result[`${type}SinglePromiseWithArgCalled1`] = arg;
 				return Promise.resolve(arg + 1);
 			});
-			result[`${type}SinglePromiseWithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}SinglePromiseWithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -556,11 +667,16 @@ class HookTester {
 				result[`${type}MultiplePromiseWithArgCalled2`] = arg;
 				return Promise.resolve(arg + 2);
 			});
-			result[`${type}MultiplePromiseWithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultiplePromiseWithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["x"], `${type}MultiplePromiseWithArgNoReturn`);
+			const hook = this.createHook(
+				["x"],
+				`${type}MultiplePromiseWithArgNoReturn`
+			);
 			hook.tapPromise("promise1", arg => {
 				result[`${type}MultiplePromiseWithArgNoReturnCalled1`] = arg;
 				return Promise.resolve();
@@ -569,11 +685,16 @@ class HookTester {
 				result[`${type}MultiplePromiseWithArgNoReturnCalled2`] = arg;
 				return Promise.resolve();
 			});
-			result[`${type}MultiplePromiseWithArgNoReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultiplePromiseWithArgNoReturn`] = await this.gainResult(
+				cb => hook[type](42, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["x"], `${type}MultiplePromiseWithArgFirstReturn`);
+			const hook = this.createHook(
+				["x"],
+				`${type}MultiplePromiseWithArgFirstReturn`
+			);
 			hook.tapPromise("promise1", arg => {
 				result[`${type}MultiplePromiseWithArgFirstReturnCalled1`] = arg;
 				return Promise.resolve(arg + 1);
@@ -582,11 +703,16 @@ class HookTester {
 				result[`${type}MultiplePromiseWithArgFirstReturnCalled2`] = arg;
 				return Promise.resolve();
 			});
-			result[`${type}MultiplePromiseWithArgFirstReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[
+				`${type}MultiplePromiseWithArgFirstReturn`
+			] = await this.gainResult(cb => hook[type](42, cb));
 		}
 
 		{
-			const hook = this.createHook(["x"], `${type}MultiplePromiseWithArgLastReturn`);
+			const hook = this.createHook(
+				["x"],
+				`${type}MultiplePromiseWithArgLastReturn`
+			);
 			hook.tapPromise("promise1", arg => {
 				result[`${type}MultiplePromiseWithArgLastReturnCalled1`] = arg;
 				return Promise.resolve();
@@ -595,7 +721,9 @@ class HookTester {
 				result[`${type}MultiplePromiseWithArgLastReturnCalled2`] = arg;
 				return Promise.resolve(arg + 2);
 			});
-			result[`${type}MultiplePromiseWithArgLastReturn`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultiplePromiseWithArgLastReturn`] = await this.gainResult(
+				cb => hook[type](42, cb)
+			);
 		}
 
 		{
@@ -612,7 +740,9 @@ class HookTester {
 				result[`${type}MultipleMixed1WithArgCalled3`] = arg;
 				return arg + 3;
 			});
-			result[`${type}MultipleMixed1WithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleMixed1WithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -625,7 +755,9 @@ class HookTester {
 				result[`${type}MultipleMixed2WithArgCalled2`] = arg;
 				return Promise.resolve(arg + 2);
 			});
-			result[`${type}MultipleMixed2WithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleMixed2WithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -642,7 +774,9 @@ class HookTester {
 				result[`${type}MultipleMixed3WithArgCalled3`] = arg;
 				setTimeout(() => callback(null, arg + 3), 100);
 			});
-			result[`${type}MultipleMixed3WithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleMixed3WithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -651,92 +785,110 @@ class HookTester {
 				result[`${type}MultipleSyncErrorCalled1`] = true;
 			});
 			hook.tap("sync2", () => {
-				throw new Error("Error in sync2")
+				throw new Error("Error in sync2");
 			});
 			hook.tap("sync3", () => {
 				result[`${type}MultipleSyncErrorCalled3`] = true;
 			});
-			result[`${type}MultipleSyncError`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultipleSyncError`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${type}MultipleAsyncError`);
-			hook.tapAsync("async1", (callback) => {
+			hook.tapAsync("async1", callback => {
 				result[`${type}MultipleAsyncErrorCalled1`] = true;
 				callback();
 			});
-			hook.tapAsync("async2", (callback) => {
+			hook.tapAsync("async2", callback => {
 				callback(new Error("Error in async2"));
 			});
-			hook.tapAsync("async3", (callback) => {
+			hook.tapAsync("async3", callback => {
 				result[`${type}MultipleAsyncErrorCalled3`] = true;
 				callback();
 			});
-			result[`${type}MultipleAsyncError`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultipleAsyncError`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${type}MultipleAsyncLateError`);
-			hook.tapAsync("async1", (callback) => {
+			hook.tapAsync("async1", callback => {
 				result[`${type}MultipleAsyncLateErrorCalled1`] = true;
 				callback();
 			});
-			hook.tapAsync("async2", (callback) => {
+			hook.tapAsync("async2", callback => {
 				setTimeout(() => callback(new Error("Error in async2")), 100);
 			});
-			hook.tapAsync("async3", (callback) => {
+			hook.tapAsync("async3", callback => {
 				result[`${type}MultipleAsyncLateErrorCalled3`] = true;
 				callback();
 			});
-			result[`${type}MultipleAsyncLateError`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultipleAsyncLateError`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
-			const hook = this.createHook([], `${type}MultipleAsyncLateErrorEarlyResult1`);
-			hook.tapAsync("async1", (callback) => {
+			const hook = this.createHook(
+				[],
+				`${type}MultipleAsyncLateErrorEarlyResult1`
+			);
+			hook.tapAsync("async1", callback => {
 				result[`${type}MultipleAsyncLateErrorEarlyResult1Called1`] = true;
 				callback();
 			});
-			hook.tapAsync("async2", (callback) => {
+			hook.tapAsync("async2", callback => {
 				setTimeout(() => callback(new Error("Error in async2")), 100);
 			});
-			hook.tapAsync("async3", (callback) => {
+			hook.tapAsync("async3", callback => {
 				result[`${type}MultipleAsyncLateErrorEarlyResult1Called3`] = true;
 				callback(null, 7);
 			});
-			result[`${type}MultipleAsyncLateErrorEarlyResult1`] = await this.gainResult((cb) => hook[type](cb));
+			result[
+				`${type}MultipleAsyncLateErrorEarlyResult1`
+			] = await this.gainResult(cb => hook[type](cb));
 		}
 
 		{
-			const hook = this.createHook([], `${type}MultipleAsyncLateErrorEarlyResult2`);
-			hook.tapAsync("async1", (callback) => {
+			const hook = this.createHook(
+				[],
+				`${type}MultipleAsyncLateErrorEarlyResult2`
+			);
+			hook.tapAsync("async1", callback => {
 				result[`${type}MultipleAsyncLateErrorEarlyResult2Called1`] = true;
 				setTimeout(() => callback(null, 42), 200);
 			});
-			hook.tapAsync("async2", (callback) => {
+			hook.tapAsync("async2", callback => {
 				setTimeout(() => callback(new Error("Error in async2")), 100);
 			});
-			hook.tapAsync("async3", (callback) => {
+			hook.tapAsync("async3", callback => {
 				result[`${type}MultipleAsyncLateErrorEarlyResult2Called3`] = true;
 				callback(null, 7);
 			});
-			result[`${type}MultipleAsyncLateErrorEarlyResult2`] = await this.gainResult((cb) => hook[type](cb));
+			result[
+				`${type}MultipleAsyncLateErrorEarlyResult2`
+			] = await this.gainResult(cb => hook[type](cb));
 		}
 
 		{
 			const hook = this.createHook([], `${type}MultipleAsyncEarlyError`);
-			hook.tapAsync("async1", (callback) => {
+			hook.tapAsync("async1", callback => {
 				result[`${type}MultipleAsyncEarlyErrorCalled1`] = true;
 				setTimeout(() => callback(), 100);
 			});
-			hook.tapAsync("async2", (callback) => {
+			hook.tapAsync("async2", callback => {
 				callback(new Error("Error in async2"));
 			});
-			hook.tapAsync("async3", (callback) => {
+			hook.tapAsync("async3", callback => {
 				result[`${type}MultipleAsyncEarlyErrorCalled3`] = true;
 				setTimeout(() => callback(), 100);
 			});
-			result[`${type}MultipleAsyncEarlyError`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultipleAsyncEarlyError`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
@@ -746,13 +898,17 @@ class HookTester {
 				return Promise.resolve();
 			});
 			hook.tapPromise("promise2", () => {
-				return Promise.resolve().then(() => { throw new Error("Error in async2"); });
+				return Promise.resolve().then(() => {
+					throw new Error("Error in async2");
+				});
 			});
 			hook.tapPromise("promise3", () => {
 				result[`${type}MultiplePromiseErrorCalled3`] = true;
 				return Promise.resolve();
 			});
-			result[`${type}MultiplePromiseError`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultiplePromiseError`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
@@ -770,7 +926,9 @@ class HookTester {
 				result[`${type}MultiplePromiseLateErrorCalled3`] = true;
 				return Promise.resolve();
 			});
-			result[`${type}MultiplePromiseLateError`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultiplePromiseLateError`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
@@ -780,13 +938,17 @@ class HookTester {
 				return new Promise(resolve => setTimeout(() => resolve(), 100));
 			});
 			hook.tapPromise("promise2", () => {
-				return Promise.resolve().then(() => { throw new Error("Error in async2"); });
+				return Promise.resolve().then(() => {
+					throw new Error("Error in async2");
+				});
 			});
 			hook.tapPromise("promise3", () => {
 				result[`${type}MultiplePromiseEarlyErrorCalled3`] = true;
 				return new Promise(resolve => setTimeout(() => resolve(), 100));
 			});
-			result[`${type}MultiplePromiseEarlyError`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultiplePromiseEarlyError`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 
 		{
@@ -803,7 +965,9 @@ class HookTester {
 				result[`${type}MultipleMixedError1WithArgCalled3`] = arg;
 				throw new Error("Error in sync");
 			});
-			result[`${type}MultipleMixedError1WithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleMixedError1WithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -814,13 +978,17 @@ class HookTester {
 			});
 			hook.tapPromise("promise", arg => {
 				result[`${type}MultipleMixedError2WithArgCalled2`] = arg;
-				return Promise.resolve().then(() => { throw new Error("Error in promise"); });
+				return Promise.resolve().then(() => {
+					throw new Error("Error in promise");
+				});
 			});
 			hook.tap("sync", arg => {
 				result[`${type}MultipleMixedError2WithArgCalled3`] = arg;
 				return arg + 2;
 			});
-			result[`${type}MultipleMixedError2WithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleMixedError2WithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
@@ -837,12 +1005,14 @@ class HookTester {
 				result[`${type}MultipleMixedError3WithArgCalled3`] = arg;
 				return arg + 2;
 			});
-			result[`${type}MultipleMixedError3WithArg`] = await this.gainResult((cb) => hook[type](42, cb));
+			result[`${type}MultipleMixedError3WithArg`] = await this.gainResult(cb =>
+				hook[type](42, cb)
+			);
 		}
 
 		{
 			const hook = this.createHook([], `${type}MultipleMixedLateError`);
-			hook.tapAsync("async", (callback) => {
+			hook.tapAsync("async", callback => {
 				result[`${type}MultipleMixedLateErrorCalled1`] = true;
 				setTimeout(() => callback(new Error("Error in async")), 100);
 			});
@@ -854,7 +1024,9 @@ class HookTester {
 				result[`${type}MultipleMixedLateErrorCalled3`] = true;
 				return 43;
 			});
-			result[`${type}MultipleMixedLateError`] = await this.gainResult((cb) => hook[type](cb));
+			result[`${type}MultipleMixedLateError`] = await this.gainResult(cb =>
+				hook[type](cb)
+			);
 		}
 	}
 
@@ -865,26 +1037,35 @@ class HookTester {
 				call: (a, b, c) => {
 					result[`${type}InterceptedCall1`] = [a, b, c];
 				},
-				tap: (tap) => {
-					result[`${type}InterceptedTap1`] = Object.assign({}, tap, { fn: tap.fn.length });
+				tap: tap => {
+					result[`${type}InterceptedTap1`] = Object.assign({}, tap, {
+						fn: tap.fn.length
+					});
 				}
 			});
 			hook.intercept({
 				call: (a, b, c) => {
 					result[`${type}InterceptedCall2`] = [a, b, c];
 				},
-				tap: (tap) => {
-					if(!result[`${type}InterceptedTap2`])
-						result[`${type}InterceptedTap2`] = Object.assign({}, tap, { fn: tap.fn.length });
+				tap: tap => {
+					if (!result[`${type}InterceptedTap2`])
+						result[`${type}InterceptedTap2`] = Object.assign({}, tap, {
+							fn: tap.fn.length
+						});
 				}
 			});
 			hook.tap("sync", (a, b, c) => a + b + c);
 			hook.tapPromise("promise", (a, b) => Promise.resolve(a + b + 1));
-			result[`${type}Intercepted`] = await this.gainResult((cb) => hook[type](1, 2, 3, cb));
+			result[`${type}Intercepted`] = await this.gainResult(cb =>
+				hook[type](1, 2, 3, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["a", "b", "c"], `${type}ContextIntercepted`);
+			const hook = this.createHook(
+				["a", "b", "c"],
+				`${type}ContextIntercepted`
+			);
 			hook.intercept({
 				call: (context, a, b, c) => {
 					context.number = 42;
@@ -904,15 +1085,23 @@ class HookTester {
 					result[`${type}ContextInterceptedCall2`] = [a, b, c];
 				}
 			});
-			hook.tap({
-				name: "sync",
-				context: true
-			}, (context, a, b, c) => context.number + a + b + c);
-			result[`${type}ContextIntercepted`] = await this.gainResult((cb) => hook[type](1, 2, 3, cb));
+			hook.tap(
+				{
+					name: "sync",
+					context: true
+				},
+				(context, a, b, c) => context.number + a + b + c
+			);
+			result[`${type}ContextIntercepted`] = await this.gainResult(cb =>
+				hook[type](1, 2, 3, cb)
+			);
 		}
 
 		{
-			const hook = this.createHook(["a", "b", "c"], `${type}UnusedContextIntercepted`);
+			const hook = this.createHook(
+				["a", "b", "c"],
+				`${type}UnusedContextIntercepted`
+			);
 			hook.intercept({
 				call: (context, a, b, c) => {
 					result[`${type}UnusedContextInterceptedCall1`] = [context, a, b, c];
@@ -928,65 +1117,85 @@ class HookTester {
 				}
 			});
 			hook.tap("sync", (a, b, c) => a + b + c);
-			result[`${type}UnusedContextIntercepted`] = await this.gainResult((cb) => hook[type](1, 2, 3, cb));
+			result[`${type}UnusedContextIntercepted`] = await this.gainResult(cb =>
+				hook[type](1, 2, 3, cb)
+			);
 		}
 	}
 
 	gainResult(fn) {
-		return Promise.race([new Promise(resolve => {
-			try {
-				const ret = fn((err, result) => {
-					if(err) {
+		return Promise.race([
+			new Promise(resolve => {
+				try {
+					const ret = fn((err, result) => {
+						if (err) {
+							resolve({
+								type: "async",
+								error: err.message
+							});
+						} else {
+							resolve({
+								type: "async",
+								value: result
+							});
+						}
+					});
+					if (ret instanceof Promise) {
+						resolve(
+							ret.then(
+								res => ({
+									type: "promise",
+									value: res
+								}),
+								err => ({
+									type: "promise",
+									error: err.message
+								})
+							)
+						);
+					} else if (ret !== undefined) {
 						resolve({
-							type: "async",
-							error: err.message
-						});
-					} else {
-						resolve({
-							type: "async",
-							value: result
+							type: "return",
+							value: ret
 						});
 					}
-				});
-				if(ret instanceof Promise) {
-					resolve(ret.then(res => ({
-						type: "promise",
-						value: res
-					}), err => ({
-						type: "promise",
-						error: err.message
-					})));
-				} else if(ret !== undefined) {
+				} catch (e) {
 					resolve({
-						type: "return",
-						value: ret
-					})
+						error: e.message
+					});
 				}
-			} catch(e) {
-				resolve({
-					error: e.message
-				});
-			}
-		}), new Promise(resolve => {
-			setTimeout(() => resolve({
-				type: "no result"
-			}), 1000);
-		})]);
+			}),
+			new Promise(resolve => {
+				setTimeout(
+					() =>
+						resolve({
+							type: "no result"
+						}),
+					1000
+				);
+			})
+		]);
 	}
 
 	createHook(args, name) {
 		try {
 			return this.hookCreator(args, name);
-		} catch(err) {
+		} catch (err) {
 			return {
 				tap: () => {},
 				tapPromise: () => {},
 				tapAsync: () => {},
 				intercept: () => {},
-				call: () => { throw err; },
-				callAsync: () => { throw err; },
-				promise: () => { throw err; },
-			}
+				call: () => {
+					throw err;
+				},
+				callAsync: () => {
+					throw err;
+				},
+				promise: () => {
+					throw err;
+				}
+			};
 		}
 	}
 }

--- a/lib/__tests__/MultiHook.js
+++ b/lib/__tests__/MultiHook.js
@@ -10,7 +10,7 @@ const MultiHook = require("../MultiHook");
 
 describe("MultiHook", () => {
 	const redirectedMethods = ["tap", "tapAsync", "tapPromise"];
-	for(const name of redirectedMethods) {
+	for (const name of redirectedMethods) {
 		it(`should redirect ${name}`, () => {
 			const calls = [];
 			const fakeHook = {
@@ -28,30 +28,27 @@ describe("MultiHook", () => {
 	it("should redirect intercept", () => {
 		const calls = [];
 		const fakeHook = {
-			intercept: (interceptor) => {
+			intercept: interceptor => {
 				calls.push(interceptor);
 			}
 		};
 		new MultiHook([fakeHook, fakeHook]).intercept("interceptor");
-		expect(calls).toEqual([
-			"interceptor",
-			"interceptor"
-		]);
+		expect(calls).toEqual(["interceptor", "interceptor"]);
 	});
 	it("should redirect withOptions", () => {
 		const calls = [];
 		const fakeHook = {
-			withOptions: (options) => {
+			withOptions: options => {
 				calls.push(options);
 				return {
 					tap: (options, fn) => {
 						calls.push({ options, fn });
 					}
-				}
+				};
 			}
 		};
 		const newHook = new MultiHook([fakeHook, fakeHook]).withOptions("options");
-		newHook.tap("options", "fn")
+		newHook.tap("options", "fn");
 		expect(calls).toEqual([
 			"options",
 			"options",

--- a/lib/__tests__/SyncBailHook.js
+++ b/lib/__tests__/SyncBailHook.js
@@ -17,7 +17,7 @@ describe("SyncBailHook", () => {
 		let r = h1.call(1);
 		expect(r).toEqual(undefined);
 
-		h1.tap("A", (a) => undefined);
+		h1.tap("A", a => undefined);
 		h2.tap("A", (a, b) => [a, b]);
 
 		expect(h1.call(1)).toEqual(undefined);
@@ -27,7 +27,7 @@ describe("SyncBailHook", () => {
 		expect(await h2.promise(1, 2)).toEqual([1, 2]);
 		expect(await pify(cb => h2.callAsync(1, 2, cb))).toEqual([1, 2]);
 
-		h1.tap("B", (a) => "ok" + a);
+		h1.tap("B", a => "ok" + a);
 		h2.tap("B", (a, b) => "wrong");
 
 		expect(h1.call(10)).toEqual("ok10");
@@ -66,10 +66,8 @@ describe("SyncBailHook", () => {
 function pify(fn) {
 	return new Promise((resolve, reject) => {
 		fn((err, result) => {
-			if(err)
-				reject(err);
-			else
-				resolve(result);
+			if (err) reject(err);
+			else resolve(result);
 		});
 	});
 }

--- a/lib/__tests__/SyncHook.js
+++ b/lib/__tests__/SyncHook.js
@@ -27,7 +27,7 @@ describe("SyncHook", () => {
 		expect(mock0).toHaveBeenLastCalledWith();
 
 		const mock1 = jest.fn();
-		h0.tap("B", mock1)
+		h0.tap("B", mock1);
 
 		h0.call();
 
@@ -67,7 +67,7 @@ describe("SyncHook", () => {
 		expect(mock5).toHaveBeenLastCalledWith("x", "y", undefined);
 	});
 
-	it("should allow to intercept calls", () =>{
+	it("should allow to intercept calls", () => {
 		const hook = new SyncHook(["arg1", "arg2"]);
 
 		const mockCall = jest.fn();
@@ -100,5 +100,5 @@ describe("SyncHook", () => {
 		expect(mock1).not.toHaveBeenLastCalledWith(1, 2);
 		expect(mock2).not.toHaveBeenLastCalledWith(1, 2);
 		expect(mock0).toHaveBeenLastCalledWith(1, 2);
-	})
+	});
 });

--- a/lib/__tests__/SyncHooks.js
+++ b/lib/__tests__/SyncHooks.js
@@ -11,41 +11,57 @@ const SyncWaterfallHook = require("../SyncWaterfallHook");
 const SyncLoopHook = require("../SyncLoopHook");
 
 describe("SyncHook", () => {
-	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new SyncHook(args));
+	it(
+		"should have to correct behavior",
+		async () => {
+			const tester = new HookTester(args => new SyncHook(args));
 
-		const result = await tester.run(true);
+			const result = await tester.run(true);
 
-		expect(result).toMatchSnapshot();
-	}, 15000)
-})
+			expect(result).toMatchSnapshot();
+		},
+		15000
+	);
+});
 
 describe("SyncBailHook", () => {
-	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new SyncBailHook(args));
+	it(
+		"should have to correct behavior",
+		async () => {
+			const tester = new HookTester(args => new SyncBailHook(args));
 
-		const result = await tester.run(true);
+			const result = await tester.run(true);
 
-		expect(result).toMatchSnapshot();
-	}, 15000)
-})
+			expect(result).toMatchSnapshot();
+		},
+		15000
+	);
+});
 
 describe("SyncWaterfallHook", () => {
-	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new SyncWaterfallHook(args));
+	it(
+		"should have to correct behavior",
+		async () => {
+			const tester = new HookTester(args => new SyncWaterfallHook(args));
 
-		const result = await tester.run(true);
+			const result = await tester.run(true);
 
-		expect(result).toMatchSnapshot();
-	}, 15000)
-})
+			expect(result).toMatchSnapshot();
+		},
+		15000
+	);
+});
 
 describe("SyncLoopHook", () => {
-	it("should have to correct behavior", async () => {
-		const tester = new HookTester((args) => new SyncLoopHook(args));
+	it(
+		"should have to correct behavior",
+		async () => {
+			const tester = new HookTester(args => new SyncLoopHook(args));
 
-		const result = await tester.runForLoop(true);
+			const result = await tester.runForLoop(true);
 
-		expect(result).toMatchSnapshot();
-	}, 15000)
-})
+			expect(result).toMatchSnapshot();
+		},
+		15000
+	);
+});

--- a/lib/__tests__/Tapable.js
+++ b/lib/__tests__/Tapable.js
@@ -17,7 +17,7 @@ describe("Tapable", () => {
 		let called = 0;
 		t.plugin("my-hook", () => called++);
 		t.hooks.myHook.call();
-		t.plugin("myHook", () => called += 10);
+		t.plugin("myHook", () => (called += 10));
 		t.hooks.myHook.call();
 		expect(called).toEqual(12);
 	});
@@ -42,13 +42,17 @@ describe("Tapable", () => {
 		let called = 0;
 		t._pluginCompat.tap("hookMap custom mapping", options => {
 			const match = /^hookMap (.+)$/.exec(options.name);
-			if(match) {
-				t.hooks.hookMap.tap(match[1], options.fn.name || "unnamed compat plugin", options.fn);
+			if (match) {
+				t.hooks.hookMap.tap(
+					match[1],
+					options.fn.name || "unnamed compat plugin",
+					options.fn
+				);
 				return true;
 			}
-		})
+		});
 		t.plugin("my-hook", () => called++);
-		t.plugin("hookMap test", () => called += 10);
+		t.plugin("hookMap test", () => (called += 10));
 		t.hooks.myHook.call();
 		expect(called).toEqual(1);
 		t.hooks.hookMap.for("test").call();
@@ -56,4 +60,4 @@ describe("Tapable", () => {
 		t.hooks.hookMap.for("other").call();
 		expect(called).toEqual(11);
 	});
-})
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "codecov": "^2.3.0",
-    "jest": "^21.0.4"
+    "jest": "^21.0.4",
+    "prettier": "^1.13.2"
   },
   "engines": {
     "node": ">=6"
@@ -26,7 +27,8 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
-    "travis": "jest --coverage && codecov"
+    "travis": "jest --coverage && codecov",
+    "pretty": "prettier --write lib/*.js lib/__tests__/*.js"
   },
   "jest": {
     "transform": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,6 +2231,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.13.2:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.4.tgz#31bbae6990f13b1093187c731766a14036fa72e6"
+
 pretty-format@^21.1.0:
   version "21.1.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.1.0.tgz#557428254323832ee8b7c971cb613442bea67f61"


### PR DESCRIPTION
Hello. This PR adds [PrettierJS](https://prettier.io), formats all the codebase using [this config](https://github.com/webpack/webpack/blob/master/.prettierrc.js), and adds a corresponding command to npm scripts.

Thank you for checking this out. I hope you'll find it useful.