### PR TITLE
Use correct method in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ myCar.hooks.calculateRoutes.intercept({
 	call: (source, target, routesList) => {
 		console.log("Starting to calculate routes");
 	},
-	tap: (tapInfo) => {
+	register: (tapInfo) => {
 		// tapInfo = { type: "promise", name: "GoogleMapsPlugin", fn: ... }
 		console.log(`${tapInfo.name} is doing it's job`);
 		return tapInfo; // may return a new tapInfo object


### PR DESCRIPTION
I noticed this while writing a webpack plugin, `tap` can't return a modification, `register` can, so that's the correct method to show.