### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Tobias Koppers @sokra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
The MIT requires full license text to be present (fixes #66)

@naterkane @sokra Particular license terms matter (citing from https://github.com/babel/babel/pull/7308#issuecomment-367686736):

> legally, it is not satisfactory to have the license name alone in the package.
>
> > This is also explicitly required by some licenses in order for it to take effect, such as ICS, Apache 2.0, all GNU licenses and MIT.
>
> The MIT license requires that "the above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software." By including the license in the source file, you have met this obligation.
>
> > Not specifying the license text in each package restrictedly means that no one may reproduce, distribute, or create derivative works from your work. The name of the license alone does not "apply" the license, hence it retains the default license instead.
>
> without a license, the default copyright laws apply, meaning that you retain all rights to your source code and no one may reproduce, distribute, or create derivative works from your work.