### PR TITLE
Deprecate HookMap.tap methods

### DIFF
--- a/lib/HookMap.js
+++ b/lib/HookMap.js
@@ -4,6 +4,10 @@
 */
 "use strict";
 
+const util = require("util");
+
+const defaultFactory = (key, hook) => hook;
+
 class HookMap {
 	constructor(factory) {
 		this._map = new Map();
@@ -33,24 +37,24 @@ class HookMap {
 		this._interceptors.push(
 			Object.assign(
 				{
-					factory: (key, hook) => hook
+					factory: defaultFactory
 				},
 				interceptor
 			)
 		);
 	}
-
-	tap(key, options, fn) {
-		return this.for(key).tap(options, fn);
-	}
-
-	tapAsync(key, options, fn) {
-		return this.for(key).tapAsync(options, fn);
-	}
-
-	tapPromise(key, options, fn) {
-		return this.for(key).tapPromise(options, fn);
-	}
 }
+
+HookMap.prototype.tap = util.deprecate(function(key, options, fn) {
+	return this.for(key).tap(options, fn);
+}, "HookMap#tap(key,…) is deprecated. Use HookMap#for(key).tap(…) instead.");
+
+HookMap.prototype.tapAsync = util.deprecate(function(key, options, fn) {
+	return this.for(key).tapAsync(options, fn);
+}, "HookMap#tapAsync(key,…) is deprecated. Use HookMap#for(key).tapAsync(…) instead.");
+
+HookMap.prototype.tapPromise = util.deprecate(function(key, options, fn) {
+	return this.for(key).tapPromise(options, fn);
+}, "HookMap#tapPromise(key,…) is deprecated. Use HookMap#for(key).tapPromise(…) instead.");
 
 module.exports = HookMap;

--- a/lib/__tests__/Tapable.js
+++ b/lib/__tests__/Tapable.js
@@ -43,11 +43,9 @@ describe("Tapable", () => {
 		t._pluginCompat.tap("hookMap custom mapping", options => {
 			const match = /^hookMap (.+)$/.exec(options.name);
 			if (match) {
-				t.hooks.hookMap.tap(
-					match[1],
-					options.fn.name || "unnamed compat plugin",
-					options.fn
-				);
+				t.hooks.hookMap
+					.for(match[1])
+					.tap(options.fn.name || "unnamed compat plugin", options.fn);
 				return true;
 			}
 		});


### PR DESCRIPTION
In order to simplify the typings and to clean this package, I propose to remove these redundant methods in the next major version. Meanwhile, they are marked as deprecated.