### PR TITLE
Deprecate context option

### DIFF
--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -4,6 +4,11 @@
 */
 "use strict";
 
+const util = require("util");
+
+const deprecateContext = util.deprecate(() => {},
+"Hook.context is deprecated and will be removed");
+
 class Hook {
 	constructor(args) {
 		if (!Array.isArray(args)) args = [];
@@ -35,9 +40,10 @@ class Hook {
 			throw new Error(
 				"Invalid arguments to tap(options: Object, fn: function)"
 			);
-		options = Object.assign({ type: "sync", fn: fn }, options);
 		if (typeof options.name !== "string" || options.name === "")
 			throw new Error("Missing name for tap");
+		if (typeof options.context !== "undefined") deprecateContext();
+		options = Object.assign({ type: "sync", fn: fn }, options);
 		options = this._runRegisterInterceptors(options);
 		this._insert(options);
 	}
@@ -48,9 +54,10 @@ class Hook {
 			throw new Error(
 				"Invalid arguments to tapAsync(options: Object, fn: function)"
 			);
-		options = Object.assign({ type: "async", fn: fn }, options);
 		if (typeof options.name !== "string" || options.name === "")
 			throw new Error("Missing name for tapAsync");
+		if (typeof options.context !== "undefined") deprecateContext();
+		options = Object.assign({ type: "async", fn: fn }, options);
 		options = this._runRegisterInterceptors(options);
 		this._insert(options);
 	}
@@ -61,9 +68,10 @@ class Hook {
 			throw new Error(
 				"Invalid arguments to tapPromise(options: Object, fn: function)"
 			);
-		options = Object.assign({ type: "promise", fn: fn }, options);
 		if (typeof options.name !== "string" || options.name === "")
 			throw new Error("Missing name for tapPromise");
+		if (typeof options.context !== "undefined") deprecateContext();
+		options = Object.assign({ type: "promise", fn: fn }, options);
 		options = this._runRegisterInterceptors(options);
 		this._insert(options);
 	}
@@ -72,7 +80,9 @@ class Hook {
 		for (const interceptor of this.interceptors) {
 			if (interceptor.register) {
 				const newOptions = interceptor.register(options);
-				if (newOptions !== undefined) options = newOptions;
+				if (newOptions !== undefined) {
+					options = newOptions;
+				}
 			}
 		}
 		return options;
@@ -87,8 +97,8 @@ class Hook {
 		const base = this._withOptionsBase || this;
 		const newHook = Object.create(base);
 
-		(newHook.tapAsync = (opt, fn) => base.tapAsync(mergeOptions(opt), fn)),
-			(newHook.tap = (opt, fn) => base.tap(mergeOptions(opt), fn));
+		newHook.tap = (opt, fn) => base.tap(mergeOptions(opt), fn);
+		newHook.tapAsync = (opt, fn) => base.tapAsync(mergeOptions(opt), fn);
 		newHook.tapPromise = (opt, fn) => base.tapPromise(mergeOptions(opt), fn);
 		newHook._withOptions = options;
 		newHook._withOptionsBase = base;
@@ -103,8 +113,9 @@ class Hook {
 		this._resetCompilation();
 		this.interceptors.push(Object.assign({}, interceptor));
 		if (interceptor.register) {
-			for (let i = 0; i < this.taps.length; i++)
+			for (let i = 0; i < this.taps.length; i++) {
 				this.taps[i] = interceptor.register(this.taps[i]);
+			}
 		}
 	}
 
@@ -117,12 +128,15 @@ class Hook {
 	_insert(item) {
 		this._resetCompilation();
 		let before;
-		if (typeof item.before === "string") before = new Set([item.before]);
-		else if (Array.isArray(item.before)) {
+		if (typeof item.before === "string") {
+			before = new Set([item.before]);
+		} else if (Array.isArray(item.before)) {
 			before = new Set(item.before);
 		}
 		let stage = 0;
-		if (typeof item.stage === "number") stage = item.stage;
+		if (typeof item.stage === "number") {
+			stage = item.stage;
+		}
 		let i = this.taps.length;
 		while (i > 0) {
 			i--;


### PR DESCRIPTION
`context` makes `tap` hard to type and is not required at all since the same result could be achieved in user-land.