### PR TITLE
Deprecate Hook#withOptions

### DIFF
--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -88,23 +88,6 @@ class Hook {
 		return options;
 	}
 
-	withOptions(options) {
-		const mergeOptions = opt =>
-			Object.assign({}, options, typeof opt === "string" ? { name: opt } : opt);
-
-		// Prevent creating endless prototype chains
-		options = Object.assign({}, options, this._withOptions);
-		const base = this._withOptionsBase || this;
-		const newHook = Object.create(base);
-
-		newHook.tap = (opt, fn) => base.tap(mergeOptions(opt), fn);
-		newHook.tapAsync = (opt, fn) => base.tapAsync(mergeOptions(opt), fn);
-		newHook.tapPromise = (opt, fn) => base.tapPromise(mergeOptions(opt), fn);
-		newHook._withOptions = options;
-		newHook._withOptionsBase = base;
-		return newHook;
-	}
-
 	isUsed() {
 		return this.taps.length > 0 || this.interceptors.length > 0;
 	}
@@ -186,5 +169,23 @@ Object.defineProperties(Hook.prototype, {
 		writable: true
 	}
 });
+
+Hook.prototype.withOptions = util.deprecate(function(options) {
+	const mergeOptions = opt =>
+		Object.assign({}, options, typeof opt === "string" ? { name: opt } : opt);
+
+	// Prevent creating endless prototype chains
+	options = Object.assign({}, options, this._withOptions);
+	const base = this._withOptionsBase || this;
+	const newHook = Object.create(base);
+
+	newHook.tap = (opt, fn) => base.tap(mergeOptions(opt), fn);
+	newHook.tapAsync = (opt, fn) => base.tapAsync(mergeOptions(opt), fn);
+	newHook.tapPromise = (opt, fn) => base.tapPromise(mergeOptions(opt), fn);
+	newHook._withOptions = options;
+	newHook._withOptionsBase = base;
+	return newHook;
+}, "Hook#withOptions(options) is deprecated and will be removed. " +
+	"Create a new hook or use an interceptor instead.");
 
 module.exports = Hook;

--- a/lib/MultiHook.js
+++ b/lib/MultiHook.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 
+const util = require("util");
 const Hook = require("./Hook");
 
 class MultiHook {
@@ -41,10 +42,11 @@ class MultiHook {
 			hook.intercept(interceptor);
 		}
 	}
-
-	withOptions(options) {
-		return new MultiHook(this.hooks.map(h => h.withOptions(options)));
-	}
 }
+
+MultiHook.prototype.withOptions = util.deprecate(function(options) {
+	return new MultiHook(this.hooks.map(h => h.withOptions(options)));
+}, "MultiHook#withOptions(options) is deprecated and will be removed. " +
+	"Create a new hook or use an interceptor instead.");
 
 module.exports = MultiHook;


### PR DESCRIPTION
`Hook#withOptions` and `MultiHook#withOptions` are niche; webpack does not even use these APIs. Since they could be replaced by an interceptor or by a new hook instance, I think it is safe to deprecate them.