### PR TITLE
Add typings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,22 +2,15 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 4
+indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 233
+max_line_length = 80
 
-[*.json]
+[*.{yml,yaml,json}]
 indent_style = space
 indent_size = 2
-
-[*.yml]
-indent_style = space
-indent_size = 2
-
-[test/cases/parsing/bom/bomfile.{css,js}]
-charset = utf-8-bom
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,13 @@
 module.exports = {
 	printWidth: 80,
 	useTabs: true,
-	tabWidth: 2
+	tabWidth: 2,
+	overrides: [
+		{
+			files: "*.json",
+			options: {
+				useTabs: false
+			}
+		}
+	]
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Just a little module for plugins.",
   "license": "MIT",
+  "homepage": "https://github.com/webpack/tapable",
   "repository": {
     "type": "git",
     "url": "http://github.com/webpack/tapable.git"
@@ -21,10 +22,11 @@
     "node": ">=6"
   },
   "files": [
-    "lib"
+    "lib",
+    "tapable.d.ts"
   ],
-  "homepage": "https://github.com/webpack/tapable",
   "main": "lib/index.js",
+  "types": "./tapable.d.ts",
   "scripts": {
     "test": "jest",
     "travis": "jest --coverage && codecov",

--- a/tapable.d.ts
+++ b/tapable.d.ts
@@ -87,9 +87,9 @@ interface HookMapInterceptor<H> {
 
 export class HookMap<H> {
 	constructor(factory: HookFactory<H>);
-	get(key: string): H;
+	get(key: string): H | undefined;
 	for(key: string): H;
-	intercept(interceptor: HookMapInterceptor<H>);
+	intercept(interceptor: HookMapInterceptor<H>): void;
 }
 
 export class MultiHook<H> {

--- a/tapable.d.ts
+++ b/tapable.d.ts
@@ -1,0 +1,100 @@
+type FixedSizeArray<T extends number, U> = T extends 0
+	? void[]
+	: ReadonlyArray<U> & {
+			0: U;
+			length: T;
+	  };
+type Measure<T extends number> = T extends 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8
+	? T
+	: never;
+type Append<T extends any[], U> = {
+	0: [U];
+	1: [T[0], U];
+	2: [T[0], T[1], U];
+	3: [T[0], T[1], T[2], U];
+	4: [T[0], T[1], T[2], T[3], U];
+	5: [T[0], T[1], T[2], T[3], T[4], U];
+	6: [T[0], T[1], T[2], T[3], T[4], T[5], U];
+	7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], U];
+	8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], U];
+}[Measure<T["length"]>];
+
+type Callback<E, T> = (error?: E, result?: T) => void;
+
+type Tap = TapOptions & {
+	name: string;
+};
+
+type TapOptions = {
+	before?: string;
+	stage?: number;
+};
+
+interface HookInterceptor<H> {
+	name?: string;
+	tap?: (tap: Tap) => void;
+	call?: (...args: any[]) => void;
+	loop?: (...args: any[]) => void;
+	register?: (hook: H) => H;
+}
+
+type ArgumentNames<T extends any[]> = FixedSizeArray<T["length"], string>;
+
+declare class Hook<T extends any[], R> {
+	constructor(args: ArgumentNames<T>);
+	intercept(interceptor: HookInterceptor<Hook<T, R>>): void;
+	isUsed(): boolean;
+	callAsync(...args: Append<T, Callback<Error, R>>): void;
+	promise(...args: T): Promise<R>;
+	tap(options: string | Tap, fn: (...args: T) => R): void;
+	withOptions(options: TapOptions): Hook<T, R>;
+}
+
+export class SyncHook<T extends any[], R = void> extends Hook<T, R> {
+	call(...args: T): R;
+}
+
+export class SyncBailHook<T extends any[], R> extends SyncHook<T, R> {}
+export class SyncLoopHook<T extends any[], R> extends SyncHook<T, R> {}
+export class SyncWaterfallHook<T extends any[]> extends SyncHook<T, T[0]> {}
+
+declare class AsyncHook<T extends any[], R> extends Hook<T, R> {
+	tapAsync(
+		options: string | Tap,
+		fn: (...args: Append<T, Callback<Error, R>>) => void
+	): void;
+	tapPromise(options: string | Tap, fn: (...args: T) => Promise<R>): void;
+}
+
+export class AsyncParallelHook<T extends any[], R> extends AsyncHook<T, R> {}
+export class AsyncParallelBailHook<T extends any[], R> extends AsyncHook<
+	T,
+	R
+> {}
+export class AsyncSeriesHook<T extends any[], R> extends AsyncHook<T, R> {}
+export class AsyncSeriesBailHook<T extends any[], R> extends AsyncHook<T, R> {}
+export class AsyncSeriesLoopHook<T extends any[], R> extends AsyncHook<T, R> {}
+export class AsyncSeriesWaterfallHook<T extends any[]> extends AsyncHook<
+	T,
+	T[0]
+> {}
+
+type HookFactory<H> = (key: string, hook?: H) => H;
+
+interface HookMapInterceptor<H> {
+	factory?: HookFactory<H>;
+}
+
+export class HookMap<H> {
+	constructor(factory: HookFactory<H>);
+	get(key: string): H;
+	for(key: string): H;
+	intercept(interceptor: HookMapInterceptor<H>);
+}
+
+export class MultiHook<H> {
+	constructor(hooks: H[]);
+	tap(options: string | Tap, fn?: Function): void;
+	tapAsync(options: string | Tap, fn?: Function): void;
+	tapPromise(options: string | Tap, fn?: Function): void;
+}


### PR DESCRIPTION
`MultiHook` is a mess but it's fine for now.

⚠️ These typings are different from the DefinitelyTyped:

```ts
// DefinitelyTyped
SyncBailHook<number, string>

// new typings
SyncBailHook<[number, string]>
```

Hooks are defined as:

```ts
Hook<[foo, bar, baz], qux>
//    ^^^  ^^^  ^^^   ^^^
//     3 arguments     |
//                     |
//     call(a: foo, b: bar, c: baz): qux
//     callAsync(a: foo, b: bar, c: baz, (err: Error, result: qux) => void): void
//     promise(a: foo, b: bar, c: baz): Promise<qux>