### PR TITLE
Exclude tests from being bundled into npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "lib",
+    "!lib/__tests__",
     "tapable.d.ts"
   ],
   "main": "lib/index.js",


### PR DESCRIPTION
Exclude tests/snapshots from being included in the distributed npm package, reduces unpacked package size from 233.5 kB to 40.7 kB (~82% reduction). Every little helps!