### PR TITLE
refactor hooks to reduce number of hidden maps in methods

### DIFF
--- a/lib/AsyncParallelBailHook.js
+++ b/lib/AsyncParallelBailHook.js
@@ -66,15 +66,20 @@ class AsyncParallelBailHookCodeFactory extends HookCodeFactory {
 
 const factory = new AsyncParallelBailHookCodeFactory();
 
-class AsyncParallelBailHook extends Hook {
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
+
+function AsyncParallelBailHook(args = []) {
+	const hook = new Hook(args);
+	hook.constructor = AsyncParallelBailHook;
+	hook.compile = COMPILE;
+	hook._call = undefined;
+	hook.call = undefined;
+	return hook;
 }
 
-Object.defineProperties(AsyncParallelBailHook.prototype, {
-	_call: { value: undefined, configurable: true, writable: true }
-});
+AsyncParallelBailHook.prototype = null;
 
 module.exports = AsyncParallelBailHook;

--- a/lib/AsyncParallelHook.js
+++ b/lib/AsyncParallelHook.js
@@ -18,15 +18,20 @@ class AsyncParallelHookCodeFactory extends HookCodeFactory {
 
 const factory = new AsyncParallelHookCodeFactory();
 
-class AsyncParallelHook extends Hook {
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
+
+function AsyncParallelHook(args = []) {
+	const hook = new Hook(args);
+	hook.constructor = AsyncParallelHook;
+	hook.compile = COMPILE;
+	hook._call = undefined;
+	hook.call = undefined;
+	return hook;
 }
 
-Object.defineProperties(AsyncParallelHook.prototype, {
-	_call: { value: undefined, configurable: true, writable: true }
-});
+AsyncParallelHook.prototype = null;
 
 module.exports = AsyncParallelHook;

--- a/lib/AsyncSeriesBailHook.js
+++ b/lib/AsyncSeriesBailHook.js
@@ -23,15 +23,20 @@ class AsyncSeriesBailHookCodeFactory extends HookCodeFactory {
 
 const factory = new AsyncSeriesBailHookCodeFactory();
 
-class AsyncSeriesBailHook extends Hook {
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
+
+function AsyncSeriesBailHook(args = []) {
+	const hook = new Hook(args);
+	hook.constructor = AsyncSeriesBailHook;
+	hook.compile = COMPILE;
+	hook._call = undefined;
+	hook.call = undefined;
+	return hook;
 }
 
-Object.defineProperties(AsyncSeriesBailHook.prototype, {
-	_call: { value: undefined, configurable: true, writable: true }
-});
+AsyncSeriesBailHook.prototype = null;
 
 module.exports = AsyncSeriesBailHook;

--- a/lib/AsyncSeriesHook.js
+++ b/lib/AsyncSeriesHook.js
@@ -18,15 +18,20 @@ class AsyncSeriesHookCodeFactory extends HookCodeFactory {
 
 const factory = new AsyncSeriesHookCodeFactory();
 
-class AsyncSeriesHook extends Hook {
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
+
+function AsyncSeriesHook(args = []) {
+	const hook = new Hook(args);
+	hook.constructor = AsyncSeriesHook;
+	hook.compile = COMPILE;
+	hook._call = undefined;
+	hook.call = undefined;
+	return hook;
 }
 
-Object.defineProperties(AsyncSeriesHook.prototype, {
-	_call: { value: undefined, configurable: true, writable: true }
-});
+AsyncSeriesHook.prototype = null;
 
 module.exports = AsyncSeriesHook;

--- a/lib/AsyncSeriesLoopHook.js
+++ b/lib/AsyncSeriesLoopHook.js
@@ -18,15 +18,20 @@ class AsyncSeriesLoopHookCodeFactory extends HookCodeFactory {
 
 const factory = new AsyncSeriesLoopHookCodeFactory();
 
-class AsyncSeriesLoopHook extends Hook {
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
+
+function AsyncSeriesLoopHook(args = []) {
+	const hook = new Hook(args);
+	hook.constructor = AsyncSeriesLoopHook;
+	hook.compile = COMPILE;
+	hook._call = undefined;
+	hook.call = undefined;
+	return hook;
 }
 
-Object.defineProperties(AsyncSeriesLoopHook.prototype, {
-	_call: { value: undefined, configurable: true, writable: true }
-});
+AsyncSeriesLoopHook.prototype = null;
 
 module.exports = AsyncSeriesLoopHook;

--- a/lib/AsyncSeriesWaterfallHook.js
+++ b/lib/AsyncSeriesWaterfallHook.js
@@ -26,21 +26,22 @@ class AsyncSeriesWaterfallHookCodeFactory extends HookCodeFactory {
 
 const factory = new AsyncSeriesWaterfallHookCodeFactory();
 
-class AsyncSeriesWaterfallHook extends Hook {
-	constructor(args) {
-		super(args);
-		if (args.length < 1)
-			throw new Error("Waterfall hooks must have at least one argument");
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
 
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+function AsyncSeriesWaterfallHook(args = []) {
+	if (args.length < 1)
+		throw new Error("Waterfall hooks must have at least one argument");
+	const hook = new Hook(args);
+	hook.constructor = AsyncSeriesWaterfallHook;
+	hook.compile = COMPILE;
+	hook._call = undefined;
+	hook.call = undefined;
+	return hook;
 }
 
-Object.defineProperties(AsyncSeriesWaterfallHook.prototype, {
-	_call: { value: undefined, configurable: true, writable: true }
-});
+AsyncSeriesWaterfallHook.prototype = null;
 
 module.exports = AsyncSeriesWaterfallHook;

--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -9,15 +9,37 @@ const util = require("util");
 const deprecateContext = util.deprecate(() => {},
 "Hook.context is deprecated and will be removed");
 
+const CALL_DELEGATE = function(...args) {
+	this.call = this._createCall("sync");
+	return this.call(...args);
+};
+const CALL_ASYNC_DELEGATE = function(...args) {
+	this.callAsync = this._createCall("async");
+	return this.callAsync(...args);
+};
+const PROMISE_DELEGATE = function(...args) {
+	this.promise = this._createCall("promise");
+	return this.promise(...args);
+};
+
 class Hook {
-	constructor(args = []) {
+	constructor(args = [], name = undefined) {
 		this._args = args;
+		this.name = name;
 		this.taps = [];
 		this.interceptors = [];
-		this.call = this._call;
-		this.promise = this._promise;
-		this.callAsync = this._callAsync;
+		this._call = CALL_DELEGATE;
+		this.call = CALL_DELEGATE;
+		this._callAsync = CALL_ASYNC_DELEGATE;
+		this.callAsync = CALL_ASYNC_DELEGATE;
+		this._promise = PROMISE_DELEGATE;
+		this.promise = PROMISE_DELEGATE;
 		this._x = undefined;
+
+		this.compile = this.compile;
+		this.tap = this.tap;
+		this.tapAsync = this.tapAsync;
+		this.tapPromise = this.tapPromise;
 	}
 
 	compile(options) {
@@ -80,17 +102,14 @@ class Hook {
 		const mergeOptions = opt =>
 			Object.assign({}, options, typeof opt === "string" ? { name: opt } : opt);
 
-		// Prevent creating endless prototype chains
-		options = Object.assign({}, options, this._withOptions);
-		const base = this._withOptionsBase || this;
-		const newHook = Object.create(base);
-
-		newHook.tap = (opt, fn) => base.tap(mergeOptions(opt), fn);
-		newHook.tapAsync = (opt, fn) => base.tapAsync(mergeOptions(opt), fn);
-		newHook.tapPromise = (opt, fn) => base.tapPromise(mergeOptions(opt), fn);
-		newHook._withOptions = options;
-		newHook._withOptionsBase = base;
-		return newHook;
+		return {
+			tap: (opt, fn) => this.tap(mergeOptions(opt), fn),
+			tapAsync: (opt, fn) => this.tapAsync(mergeOptions(opt), fn),
+			tapPromise: (opt, fn) => this.tapPromise(mergeOptions(opt), fn),
+			intercept: interceptor => this.intercept(interceptor),
+			isUsed: () => this.isUsed(),
+			withOptions: opt => this.withOptions(mergeOptions(opt))
+		};
 	}
 
 	isUsed() {
@@ -150,29 +169,6 @@ class Hook {
 	}
 }
 
-function createCompileDelegate(name, type) {
-	return function lazyCompileHook(...args) {
-		this[name] = this._createCall(type);
-		return this[name](...args);
-	};
-}
-
-Object.defineProperties(Hook.prototype, {
-	_call: {
-		value: createCompileDelegate("call", "sync"),
-		configurable: true,
-		writable: true
-	},
-	_callAsync: {
-		value: createCompileDelegate("callAsync", "async"),
-		configurable: true,
-		writable: true
-	},
-	_promise: {
-		value: createCompileDelegate("promise", "promise"),
-		configurable: true,
-		writable: true
-	}
-});
+Object.setPrototypeOf(Hook.prototype, null);
 
 module.exports = Hook;

--- a/lib/SyncBailHook.js
+++ b/lib/SyncBailHook.js
@@ -24,19 +24,28 @@ class SyncBailHookCodeFactory extends HookCodeFactory {
 
 const factory = new SyncBailHookCodeFactory();
 
-class SyncBailHook extends Hook {
-	tapAsync() {
-		throw new Error("tapAsync is not supported on a SyncBailHook");
-	}
+const TAP_ASYNC = () => {
+	throw new Error("tapAsync is not supported on a SyncBailHook");
+};
 
-	tapPromise() {
-		throw new Error("tapPromise is not supported on a SyncBailHook");
-	}
+const TAP_PROMISE = () => {
+	throw new Error("tapPromise is not supported on a SyncBailHook");
+};
 
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
+
+function SyncBailHook(args = []) {
+	const hook = new Hook(args);
+	hook.constructor = SyncBailHook;
+	hook.tapAsync = TAP_ASYNC;
+	hook.tapPromise = TAP_PROMISE;
+	hook.compile = COMPILE;
+	return hook;
 }
+
+SyncBailHook.prototype = null;
 
 module.exports = SyncBailHook;

--- a/lib/SyncHook.js
+++ b/lib/SyncHook.js
@@ -19,19 +19,28 @@ class SyncHookCodeFactory extends HookCodeFactory {
 
 const factory = new SyncHookCodeFactory();
 
-class SyncHook extends Hook {
-	tapAsync() {
-		throw new Error("tapAsync is not supported on a SyncHook");
-	}
+const TAP_ASYNC = () => {
+	throw new Error("tapAsync is not supported on a SyncHook");
+};
 
-	tapPromise() {
-		throw new Error("tapPromise is not supported on a SyncHook");
-	}
+const TAP_PROMISE = () => {
+	throw new Error("tapPromise is not supported on a SyncHook");
+};
 
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
+
+function SyncHook(args = []) {
+	const hook = new Hook(args);
+	hook.constructor = SyncHook;
+	hook.tapAsync = TAP_ASYNC;
+	hook.tapPromise = TAP_PROMISE;
+	hook.compile = COMPILE;
+	return hook;
 }
+
+SyncHook.prototype = null;
 
 module.exports = SyncHook;

--- a/lib/SyncLoopHook.js
+++ b/lib/SyncLoopHook.js
@@ -19,19 +19,28 @@ class SyncLoopHookCodeFactory extends HookCodeFactory {
 
 const factory = new SyncLoopHookCodeFactory();
 
-class SyncLoopHook extends Hook {
-	tapAsync() {
-		throw new Error("tapAsync is not supported on a SyncLoopHook");
-	}
+const TAP_ASYNC = () => {
+	throw new Error("tapAsync is not supported on a SyncLoopHook");
+};
 
-	tapPromise() {
-		throw new Error("tapPromise is not supported on a SyncLoopHook");
-	}
+const TAP_PROMISE = () => {
+	throw new Error("tapPromise is not supported on a SyncLoopHook");
+};
 
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
+
+function SyncLoopHook(args = []) {
+	const hook = new Hook(args);
+	hook.constructor = SyncLoopHook;
+	hook.tapAsync = TAP_ASYNC;
+	hook.tapPromise = TAP_PROMISE;
+	hook.compile = COMPILE;
+	return hook;
 }
+
+SyncLoopHook.prototype = null;
 
 module.exports = SyncLoopHook;

--- a/lib/SyncWaterfallHook.js
+++ b/lib/SyncWaterfallHook.js
@@ -28,25 +28,30 @@ class SyncWaterfallHookCodeFactory extends HookCodeFactory {
 
 const factory = new SyncWaterfallHookCodeFactory();
 
-class SyncWaterfallHook extends Hook {
-	constructor(args) {
-		super(args);
-		if (args.length < 1)
-			throw new Error("Waterfall hooks must have at least one argument");
-	}
+const TAP_ASYNC = () => {
+	throw new Error("tapAsync is not supported on a SyncWaterfallHook");
+};
 
-	tapAsync() {
-		throw new Error("tapAsync is not supported on a SyncWaterfallHook");
-	}
+const TAP_PROMISE = () => {
+	throw new Error("tapPromise is not supported on a SyncWaterfallHook");
+};
 
-	tapPromise() {
-		throw new Error("tapPromise is not supported on a SyncWaterfallHook");
-	}
+const COMPILE = function(options) {
+	factory.setup(this, options);
+	return factory.create(options);
+};
 
-	compile(options) {
-		factory.setup(this, options);
-		return factory.create(options);
-	}
+function SyncWaterfallHook(args = []) {
+	if (args.length < 1)
+		throw new Error("Waterfall hooks must have at least one argument");
+	const hook = new Hook(args);
+	hook.constructor = SyncWaterfallHook;
+	hook.tapAsync = TAP_ASYNC;
+	hook.tapPromise = TAP_PROMISE;
+	hook.compile = COMPILE;
+	return hook;
 }
+
+SyncWaterfallHook.prototype = null;
 
 module.exports = SyncWaterfallHook;

--- a/tapable.d.ts
+++ b/tapable.d.ts
@@ -42,7 +42,7 @@ interface HookInterceptor<H> {
 type ArgumentNames<T extends any[]> = FixedSizeArray<T["length"], string>;
 
 declare class Hook<T, R> {
-	constructor(args?: ArgumentNames<AsArray<T>>);
+	constructor(args?: ArgumentNames<AsArray<T>>, name?: string);
 	intercept(interceptor: HookInterceptor<Hook<T, R>>): void;
 	isUsed(): boolean;
 	callAsync(...args: Append<AsArray<T>, Callback<Error, R>>): void;


### PR DESCRIPTION
add `name` argument to hook, since enhanced-resolve needs it