### PR TITLE
style: Remove semicolon

### DIFF
--- a/lib/AsyncSeriesBailHook.js
+++ b/lib/AsyncSeriesBailHook.js
@@ -14,7 +14,7 @@ class AsyncSeriesBailHookCodeFactory extends HookCodeFactory {
 			onResult: (i, result, next) =>
 				`if(${result} !== undefined) {\n${onResult(
 					result
-				)};\n} else {\n${next()}}\n`,
+				)}\n} else {\n${next()}}\n`,
 			resultReturns,
 			onDone
 		});


### PR DESCRIPTION
The code after onResult execution already contains semicolons.