### PR TITLE
check invalid before names

### DIFF
--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -157,6 +157,9 @@ class Hook {
 					continue;
 				}
 				if (before.size > 0) {
+					if (i === 0) {
+						throw new Error(`Invalid before names [${[...before]}]`);
+					}
 					continue;
 				}
 			}

--- a/lib/__tests__/Hook.js
+++ b/lib/__tests__/Hook.js
@@ -67,4 +67,21 @@ describe("Hook", () => {
 		hook.call();
 		expect(calls).toEqual(["E", "F", "C", "D", "B", "A"]);
 	});
+
+	it("should throw error when pass invalid before names", () => {
+		const hook = new SyncHook();
+
+		const calls = [];
+		hook.tap("A", () => calls.push("A"));
+
+		expect(() => {
+			hook.tap(
+				{
+					name: "B",
+					before: "C"
+				},
+				() => calls.push("B")
+			);
+		}).toThrowError("Invalid before names [C]");
+	});
 });


### PR DESCRIPTION
```js
const { SyncHook } = require('./lib')

const car = new SyncHook()
const calls = []
car.tap('1', () => calls.push(1))
car.tap('2', () => calls.push(2))
car.tap('3', () => calls.push(3))
car.tap({
	before: ['3', '5'],
	name: '4'
}, () => calls.push(4))
car.call()
console.log(calls) // unexpected print [4, 1, 2, 3]
```
when pass invalid before names, should throw error