### PR TITLE
Change arrow functions in string to ES5 compatible functions

### DIFF
--- a/lib/AsyncParallelBailHook.js
+++ b/lib/AsyncParallelBailHook.js
@@ -11,7 +11,7 @@ class AsyncParallelBailHookCodeFactory extends HookCodeFactory {
 	content({ onError, onResult, onDone }) {
 		let code = "";
 		code += `var _results = new Array(${this.options.taps.length});\n`;
-		code += "var _checkDone = () => {\n";
+		code += "var _checkDone = function() {\n";
 		code += "for(var i = 0; i < _results.length; i++) {\n";
 		code += "var item = _results[i];\n";
 		code += "if(item === undefined) return false;\n";

--- a/lib/HookCodeFactory.js
+++ b/lib/HookCodeFactory.js
@@ -62,7 +62,8 @@ class HookCodeFactory {
 					code += "var _sync = true;\n";
 					code += "function _error(_err) {\n";
 					code += "if(_sync)\n";
-					code += "_resolve(Promise.resolve().then(function() { throw _err; }));\n";
+					code +=
+						"_resolve(Promise.resolve().then(function() { throw _err; }));\n";
 					code += "else\n";
 					code += "_reject(_err);\n";
 					code += "};\n";
@@ -70,8 +71,8 @@ class HookCodeFactory {
 
 				// Replace use of 'this' with previously extracted '_this'
 				// in header and in content
-				code += this.header().replace(/this\./g, '_this.');
-				code += content.replace(/this\./g, '_this.');
+				code += this.header().replace(/this\./g, "_this.");
+				code += content.replace(/this\./g, "_this.");
 				if (errorHelperUsed) {
 					code += "_sync = false;\n";
 				}
@@ -232,7 +233,8 @@ class HookCodeFactory {
 				break;
 			case "async":
 				let cbCode = "";
-				if (onResult) cbCode += `function(_err${tapIndex}, _result${tapIndex}) {\n`;
+				if (onResult)
+					cbCode += `function(_err${tapIndex}, _result${tapIndex}) {\n`;
 				else cbCode += `function(_err${tapIndex}) {\n`;
 				cbCode += `if(_err${tapIndex}) {\n`;
 				cbCode += onError(`_err${tapIndex}`);

--- a/lib/HookCodeFactory.js
+++ b/lib/HookCodeFactory.js
@@ -55,18 +55,23 @@ class HookCodeFactory {
 				});
 				let code = "";
 				code += '"use strict";\n';
-				code += "return new Promise((_resolve, _reject) => {\n";
+				// Extract _this
+				code += "var _this = this;\n";
+				code += "return new Promise(function(_resolve, _reject) {\n";
 				if (errorHelperUsed) {
 					code += "var _sync = true;\n";
 					code += "function _error(_err) {\n";
 					code += "if(_sync)\n";
-					code += "_resolve(Promise.resolve().then(() => { throw _err; }));\n";
+					code += "_resolve(Promise.resolve().then(function() { throw _err; }));\n";
 					code += "else\n";
 					code += "_reject(_err);\n";
 					code += "};\n";
 				}
-				code += this.header();
-				code += content;
+
+				// Replace use of 'this' with previously extracted '_this'
+				// in header and in content
+				code += this.header().replace(/this\./g, '_this.');
+				code += content.replace(/this\./g, '_this.');
 				if (errorHelperUsed) {
 					code += "_sync = false;\n";
 				}
@@ -227,8 +232,8 @@ class HookCodeFactory {
 				break;
 			case "async":
 				let cbCode = "";
-				if (onResult) cbCode += `(_err${tapIndex}, _result${tapIndex}) => {\n`;
-				else cbCode += `_err${tapIndex} => {\n`;
+				if (onResult) cbCode += `function(_err${tapIndex}, _result${tapIndex}) {\n`;
+				else cbCode += `function(_err${tapIndex}) {\n`;
 				cbCode += `if(_err${tapIndex}) {\n`;
 				cbCode += onError(`_err${tapIndex}`);
 				cbCode += "} else {\n";
@@ -252,7 +257,7 @@ class HookCodeFactory {
 				})});\n`;
 				code += `if (!_promise${tapIndex} || !_promise${tapIndex}.then)\n`;
 				code += `  throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise${tapIndex} + ')');\n`;
-				code += `_promise${tapIndex}.then(_result${tapIndex} => {\n`;
+				code += `_promise${tapIndex}.then(function(_result${tapIndex}) {\n`;
 				code += `_hasResult${tapIndex} = true;\n`;
 				if (onResult) {
 					code += onResult(`_result${tapIndex}`);
@@ -260,7 +265,7 @@ class HookCodeFactory {
 				if (onDone) {
 					code += onDone();
 				}
-				code += `}, _err${tapIndex} => {\n`;
+				code += `}, function(_err${tapIndex}) {\n`;
 				code += `if(_hasResult${tapIndex}) throw _err${tapIndex};\n`;
 				code += onError(`_err${tapIndex}`);
 				code += "});\n";
@@ -322,7 +327,7 @@ class HookCodeFactory {
 		const syncOnly = this.options.taps.every(t => t.type === "sync");
 		let code = "";
 		if (!syncOnly) {
-			code += "var _looper = () => {\n";
+			code += "var _looper = function() {\n";
 			code += "var _loopAsync = false;\n";
 		}
 		code += "var _loop;\n";
@@ -388,7 +393,7 @@ class HookCodeFactory {
 		code += "do {\n";
 		code += `var _counter = ${this.options.taps.length};\n`;
 		if (onDone) {
-			code += "var _done = () => {\n";
+			code += "var _done = function() {\n";
 			code += onDone();
 			code += "};\n";
 		}

--- a/lib/__tests__/__snapshots__/HookCodeFactory.js.snap
+++ b/lib/__tests__/__snapshots__/HookCodeFactory.js.snap
@@ -2,7 +2,7 @@
 
 exports[`HookCodeFactory callTap (no args, no intercept) async with onResult 1`] = `
 "var _fn1 = _x[1];
-_fn1((_err1, _result1) => {
+_fn1(function(_err1, _result1) {
 if(_err1) {
 onError(_err1);
 } else {
@@ -14,7 +14,7 @@ onResult(_result1);
 
 exports[`HookCodeFactory callTap (no args, no intercept) async with onResult 2`] = `
 "var _fn1 = _x[1];
-_fn1((_err1, _result1) => {
+_fn1(function(_err1, _result1) {
   if (_err1) {
     onError(_err1);
   } else {
@@ -26,7 +26,7 @@ _fn1((_err1, _result1) => {
 
 exports[`HookCodeFactory callTap (no args, no intercept) async without onResult 1`] = `
 "var _fn1 = _x[1];
-_fn1(_err1 => {
+_fn1(function(_err1) {
 if(_err1) {
 onError(_err1);
 } else {
@@ -38,7 +38,7 @@ onDone();
 
 exports[`HookCodeFactory callTap (no args, no intercept) async without onResult 2`] = `
 "var _fn1 = _x[1];
-_fn1(_err1 => {
+_fn1(function(_err1) {
   if (_err1) {
     onError(_err1);
   } else {
@@ -54,10 +54,10 @@ var _hasResult2 = false;
 var _promise2 = _fn2();
 if (!_promise2 || !_promise2.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
-_promise2.then(_result2 => {
+_promise2.then(function(_result2) {
 _hasResult2 = true;
 onResult(_result2);
-}, _err2 => {
+}, function(_err2) {
 if(_hasResult2) throw _err2;
 onError(_err2);
 });
@@ -75,11 +75,11 @@ if (!_promise2 || !_promise2.then)
       \\")\\"
   );
 _promise2.then(
-  _result2 => {
+  function(_result2) {
     _hasResult2 = true;
     onResult(_result2);
   },
-  _err2 => {
+  function(_err2) {
     if (_hasResult2) throw _err2;
     onError(_err2);
   }
@@ -93,10 +93,10 @@ var _hasResult2 = false;
 var _promise2 = _fn2();
 if (!_promise2 || !_promise2.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
-_promise2.then(_result2 => {
+_promise2.then(function(_result2) {
 _hasResult2 = true;
 onDone();
-}, _err2 => {
+}, function(_err2) {
 if(_hasResult2) throw _err2;
 onError(_err2);
 });
@@ -114,11 +114,11 @@ if (!_promise2 || !_promise2.then)
       \\")\\"
   );
 _promise2.then(
-  _result2 => {
+  function(_result2) {
     _hasResult2 = true;
     onDone();
   },
-  _err2 => {
+  function(_err2) {
     if (_hasResult2) throw _err2;
     onError(_err2);
   }
@@ -188,7 +188,7 @@ if (!_hasError0) {
 
 exports[`HookCodeFactory callTap (with args, no intercept) async with onResult 1`] = `
 "var _fn1 = _x[1];
-_fn1(a, b, c, (_err1, _result1) => {
+_fn1(a, b, c, function(_err1, _result1) {
 if(_err1) {
 onError(_err1);
 } else {
@@ -200,7 +200,7 @@ onResult(_result1);
 
 exports[`HookCodeFactory callTap (with args, no intercept) async with onResult 2`] = `
 "var _fn1 = _x[1];
-_fn1(a, b, c, (_err1, _result1) => {
+_fn1(a, b, c, function(_err1, _result1) {
   if (_err1) {
     onError(_err1);
   } else {
@@ -212,7 +212,7 @@ _fn1(a, b, c, (_err1, _result1) => {
 
 exports[`HookCodeFactory callTap (with args, no intercept) async without onResult 1`] = `
 "var _fn1 = _x[1];
-_fn1(a, b, c, _err1 => {
+_fn1(a, b, c, function(_err1) {
 if(_err1) {
 onError(_err1);
 } else {
@@ -224,7 +224,7 @@ onDone();
 
 exports[`HookCodeFactory callTap (with args, no intercept) async without onResult 2`] = `
 "var _fn1 = _x[1];
-_fn1(a, b, c, _err1 => {
+_fn1(a, b, c, function(_err1) {
   if (_err1) {
     onError(_err1);
   } else {
@@ -240,10 +240,10 @@ var _hasResult2 = false;
 var _promise2 = _fn2(a, b, c);
 if (!_promise2 || !_promise2.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
-_promise2.then(_result2 => {
+_promise2.then(function(_result2) {
 _hasResult2 = true;
 onResult(_result2);
-}, _err2 => {
+}, function(_err2) {
 if(_hasResult2) throw _err2;
 onError(_err2);
 });
@@ -261,11 +261,11 @@ if (!_promise2 || !_promise2.then)
       \\")\\"
   );
 _promise2.then(
-  _result2 => {
+  function(_result2) {
     _hasResult2 = true;
     onResult(_result2);
   },
-  _err2 => {
+  function(_err2) {
     if (_hasResult2) throw _err2;
     onError(_err2);
   }
@@ -279,10 +279,10 @@ var _hasResult2 = false;
 var _promise2 = _fn2(a, b, c);
 if (!_promise2 || !_promise2.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
-_promise2.then(_result2 => {
+_promise2.then(function(_result2) {
 _hasResult2 = true;
 onDone();
-}, _err2 => {
+}, function(_err2) {
 if(_hasResult2) throw _err2;
 onError(_err2);
 });
@@ -300,11 +300,11 @@ if (!_promise2 || !_promise2.then)
       \\")\\"
   );
 _promise2.then(
-  _result2 => {
+  function(_result2) {
     _hasResult2 = true;
     onDone();
   },
-  _err2 => {
+  function(_err2) {
     if (_hasResult2) throw _err2;
     onError(_err2);
   }
@@ -377,7 +377,7 @@ exports[`HookCodeFactory callTap (with args, with intercept) async with onResult
 _interceptors[0].tap(_tap1);
 _interceptors[1].tap(_tap1);
 var _fn1 = _x[1];
-_fn1(a, b, c, (_err1, _result1) => {
+_fn1(a, b, c, function(_err1, _result1) {
 if(_err1) {
 onError(_err1);
 } else {
@@ -392,7 +392,7 @@ exports[`HookCodeFactory callTap (with args, with intercept) async with onResult
 _interceptors[0].tap(_tap1);
 _interceptors[1].tap(_tap1);
 var _fn1 = _x[1];
-_fn1(a, b, c, (_err1, _result1) => {
+_fn1(a, b, c, function(_err1, _result1) {
   if (_err1) {
     onError(_err1);
   } else {
@@ -407,7 +407,7 @@ exports[`HookCodeFactory callTap (with args, with intercept) async without onRes
 _interceptors[0].tap(_tap1);
 _interceptors[1].tap(_tap1);
 var _fn1 = _x[1];
-_fn1(a, b, c, _err1 => {
+_fn1(a, b, c, function(_err1) {
 if(_err1) {
 onError(_err1);
 } else {
@@ -422,7 +422,7 @@ exports[`HookCodeFactory callTap (with args, with intercept) async without onRes
 _interceptors[0].tap(_tap1);
 _interceptors[1].tap(_tap1);
 var _fn1 = _x[1];
-_fn1(a, b, c, _err1 => {
+_fn1(a, b, c, function(_err1) {
   if (_err1) {
     onError(_err1);
   } else {
@@ -441,10 +441,10 @@ var _hasResult2 = false;
 var _promise2 = _fn2(a, b, c);
 if (!_promise2 || !_promise2.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
-_promise2.then(_result2 => {
+_promise2.then(function(_result2) {
 _hasResult2 = true;
 onResult(_result2);
-}, _err2 => {
+}, function(_err2) {
 if(_hasResult2) throw _err2;
 onError(_err2);
 });
@@ -465,11 +465,11 @@ if (!_promise2 || !_promise2.then)
       \\")\\"
   );
 _promise2.then(
-  _result2 => {
+  function(_result2) {
     _hasResult2 = true;
     onResult(_result2);
   },
-  _err2 => {
+  function(_err2) {
     if (_hasResult2) throw _err2;
     onError(_err2);
   }
@@ -486,10 +486,10 @@ var _hasResult2 = false;
 var _promise2 = _fn2(a, b, c);
 if (!_promise2 || !_promise2.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
-_promise2.then(_result2 => {
+_promise2.then(function(_result2) {
 _hasResult2 = true;
 onDone();
-}, _err2 => {
+}, function(_err2) {
 if(_hasResult2) throw _err2;
 onError(_err2);
 });
@@ -510,11 +510,11 @@ if (!_promise2 || !_promise2.then)
       \\")\\"
   );
 _promise2.then(
-  _result2 => {
+  function(_result2) {
     _hasResult2 = true;
     onDone();
   },
-  _err2 => {
+  function(_err2) {
     if (_hasResult2) throw _err2;
     onError(_err2);
   }
@@ -595,7 +595,7 @@ if (!_hasError0) {
 `;
 
 exports[`HookCodeFactory taps (mixed) callTapsLooping 1`] = `
-"var _looper = () => {
+"var _looper = function() {
 var _loopAsync = false;
 var _loop;
 do {
@@ -606,7 +606,7 @@ var _hasResult2 = false;
 var _promise2 = _fn2(a, b, c);
 if (!_promise2 || !_promise2.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
-_promise2.then(_result2 => {
+_promise2.then(function(_result2) {
 _hasResult2 = true;
 if(_result2 !== undefined) {
 _loop = true;
@@ -616,7 +616,7 @@ if(!_loop) {
 onDone();
 }
 }
-}, _err2 => {
+}, function(_err2) {
 if(_hasResult2) throw _err2;
 onError(2, _err2);
 });
@@ -635,7 +635,7 @@ _loop = true;
 if(_loopAsync) _looper();
 } else {
 var _fn1 = _x[1];
-_fn1(a, b, c, (_err1, _result1) => {
+_fn1(a, b, c, function(_err1, _result1) {
 if(_err1) {
 onError(1, _err1);
 } else {
@@ -657,7 +657,7 @@ _looper();
 `;
 
 exports[`HookCodeFactory taps (mixed) callTapsLooping 2`] = `
-"var _looper = () => {
+"var _looper = function() {
   var _loopAsync = false;
   var _loop;
   do {
@@ -673,7 +673,7 @@ exports[`HookCodeFactory taps (mixed) callTapsLooping 2`] = `
             \\")\\"
         );
       _promise2.then(
-        _result2 => {
+        function(_result2) {
           _hasResult2 = true;
           if (_result2 !== undefined) {
             _loop = true;
@@ -684,7 +684,7 @@ exports[`HookCodeFactory taps (mixed) callTapsLooping 2`] = `
             }
           }
         },
-        _err2 => {
+        function(_err2) {
           if (_hasResult2) throw _err2;
           onError(2, _err2);
         }
@@ -704,7 +704,7 @@ exports[`HookCodeFactory taps (mixed) callTapsLooping 2`] = `
         if (_loopAsync) _looper();
       } else {
         var _fn1 = _x[1];
-        _fn1(a, b, c, (_err1, _result1) => {
+        _fn1(a, b, c, function(_err1, _result1) {
           if (_err1) {
             onError(1, _err1);
           } else {
@@ -728,7 +728,7 @@ _looper();
 exports[`HookCodeFactory taps (mixed) callTapsParallel 1`] = `
 "do {
 var _counter = 3;
-var _done = () => {
+var _done = function() {
 onDone();
 };
 if(_counter <= 0) break;
@@ -744,7 +744,7 @@ _done();
 }
 if(_counter <= 0) break;
 var _fn1 = _x[1];
-_fn1(a, b, c, (_err1, _result1) => {
+_fn1(a, b, c, function(_err1, _result1) {
 if(_err1) {
 if(_counter > 0) {
 onError(1, _err1);
@@ -766,7 +766,7 @@ var _hasResult2 = false;
 var _promise2 = _fn2(a, b, c);
 if (!_promise2 || !_promise2.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
-_promise2.then(_result2 => {
+_promise2.then(function(_result2) {
 _hasResult2 = true;
 if(_counter > 0) {
 onResult(2, _result2, () => {
@@ -776,7 +776,7 @@ _counter = 0;
 _done();
 });
 }
-}, _err2 => {
+}, function(_err2) {
 if(_hasResult2) throw _err2;
 if(_counter > 0) {
 onError(2, _err2);
@@ -789,7 +789,7 @@ onError(2, _err2);
 exports[`HookCodeFactory taps (mixed) callTapsParallel 2`] = `
 "do {
   var _counter = 3;
-  var _done = () => {
+  var _done = function() {
     onDone();
   };
   if (_counter <= 0) break;
@@ -810,7 +810,7 @@ exports[`HookCodeFactory taps (mixed) callTapsParallel 2`] = `
   }
   if (_counter <= 0) break;
   var _fn1 = _x[1];
-  _fn1(a, b, c, (_err1, _result1) => {
+  _fn1(a, b, c, function(_err1, _result1) {
     if (_err1) {
       if (_counter > 0) {
         onError(1, _err1);
@@ -842,7 +842,7 @@ exports[`HookCodeFactory taps (mixed) callTapsParallel 2`] = `
         \\")\\"
     );
   _promise2.then(
-    _result2 => {
+    function(_result2) {
       _hasResult2 = true;
       if (_counter > 0) {
         onResult(
@@ -858,7 +858,7 @@ exports[`HookCodeFactory taps (mixed) callTapsParallel 2`] = `
         );
       }
     },
-    _err2 => {
+    function(_err2) {
       if (_hasResult2) throw _err2;
       if (_counter > 0) {
         onError(2, _err2);
@@ -876,14 +876,14 @@ var _hasResult2 = false;
 var _promise2 = _fn2(a, b, c);
 if (!_promise2 || !_promise2.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise2 + ')');
-_promise2.then(_result2 => {
+_promise2.then(function(_result2) {
 _hasResult2 = true;
 onResult(2, _result2, () => {
 onDone();
 }, () => {
 onDone();
 });
-}, _err2 => {
+}, function(_err2) {
 if(_hasResult2) throw _err2;
 onError(2, _err2);
 });
@@ -892,7 +892,7 @@ var _fn0 = _x[0];
 var _result0 = _fn0(a, b, c);
 onResult(0, _result0, () => {
 var _fn1 = _x[1];
-_fn1(a, b, c, (_err1, _result1) => {
+_fn1(a, b, c, function(_err1, _result1) {
 if(_err1) {
 onError(1, _err1);
 } else {
@@ -921,7 +921,7 @@ exports[`HookCodeFactory taps (mixed) callTapsSeries 2`] = `
         \\")\\"
     );
   _promise2.then(
-    _result2 => {
+    function(_result2) {
       _hasResult2 = true;
       onResult(
         2,
@@ -934,7 +934,7 @@ exports[`HookCodeFactory taps (mixed) callTapsSeries 2`] = `
         }
       );
     },
-    _err2 => {
+    function(_err2) {
       if (_hasResult2) throw _err2;
       onError(2, _err2);
     }
@@ -947,7 +947,7 @@ onResult(
   _result0,
   () => {
     var _fn1 = _x[1];
-    _fn1(a, b, c, (_err1, _result1) => {
+    _fn1(a, b, c, function(_err1, _result1) {
       if (_err1) {
         onError(1, _err1);
       } else {
@@ -972,7 +972,7 @@ onResult(
 `;
 
 exports[`HookCodeFactory taps (mixed2) callTapsLooping 1`] = `
-"var _looper = () => {
+"var _looper = function() {
 var _loopAsync = false;
 var _loop;
 do {
@@ -1003,7 +1003,7 @@ var _hasResult1 = false;
 var _promise1 = _fn1(a, b, c);
 if (!_promise1 || !_promise1.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise1 + ')');
-_promise1.then(_result1 => {
+_promise1.then(function(_result1) {
 _hasResult1 = true;
 if(_result1 !== undefined) {
 _loop = true;
@@ -1011,13 +1011,13 @@ if(_loopAsync) _looper();
 } else {
 _next1();
 }
-}, _err1 => {
+}, function(_err1) {
 if(_hasResult1) throw _err1;
 onError(1, _err1);
 });
 }
 var _fn0 = _x[0];
-_fn0(a, b, c, (_err0, _result0) => {
+_fn0(a, b, c, function(_err0, _result0) {
 if(_err0) {
 onError(0, _err0);
 } else {
@@ -1037,7 +1037,7 @@ _looper();
 `;
 
 exports[`HookCodeFactory taps (mixed2) callTapsLooping 2`] = `
-"var _looper = () => {
+"var _looper = function() {
   var _loopAsync = false;
   var _loop;
   do {
@@ -1073,7 +1073,7 @@ exports[`HookCodeFactory taps (mixed2) callTapsLooping 2`] = `
             \\")\\"
         );
       _promise1.then(
-        _result1 => {
+        function(_result1) {
           _hasResult1 = true;
           if (_result1 !== undefined) {
             _loop = true;
@@ -1082,14 +1082,14 @@ exports[`HookCodeFactory taps (mixed2) callTapsLooping 2`] = `
             _next1();
           }
         },
-        _err1 => {
+        function(_err1) {
           if (_hasResult1) throw _err1;
           onError(1, _err1);
         }
       );
     }
     var _fn0 = _x[0];
-    _fn0(a, b, c, (_err0, _result0) => {
+    _fn0(a, b, c, function(_err0, _result0) {
       if (_err0) {
         onError(0, _err0);
       } else {
@@ -1111,12 +1111,12 @@ _looper();
 exports[`HookCodeFactory taps (mixed2) callTapsParallel 1`] = `
 "do {
 var _counter = 3;
-var _done = () => {
+var _done = function() {
 onDone();
 };
 if(_counter <= 0) break;
 var _fn0 = _x[0];
-_fn0(a, b, c, (_err0, _result0) => {
+_fn0(a, b, c, function(_err0, _result0) {
 if(_err0) {
 if(_counter > 0) {
 onError(0, _err0);
@@ -1138,7 +1138,7 @@ var _hasResult1 = false;
 var _promise1 = _fn1(a, b, c);
 if (!_promise1 || !_promise1.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise1 + ')');
-_promise1.then(_result1 => {
+_promise1.then(function(_result1) {
 _hasResult1 = true;
 if(_counter > 0) {
 onResult(1, _result1, () => {
@@ -1148,7 +1148,7 @@ _counter = 0;
 _done();
 });
 }
-}, _err1 => {
+}, function(_err1) {
 if(_hasResult1) throw _err1;
 if(_counter > 0) {
 onError(1, _err1);
@@ -1172,12 +1172,12 @@ _done();
 exports[`HookCodeFactory taps (mixed2) callTapsParallel 2`] = `
 "do {
   var _counter = 3;
-  var _done = () => {
+  var _done = function() {
     onDone();
   };
   if (_counter <= 0) break;
   var _fn0 = _x[0];
-  _fn0(a, b, c, (_err0, _result0) => {
+  _fn0(a, b, c, function(_err0, _result0) {
     if (_err0) {
       if (_counter > 0) {
         onError(0, _err0);
@@ -1209,7 +1209,7 @@ exports[`HookCodeFactory taps (mixed2) callTapsParallel 2`] = `
         \\")\\"
     );
   _promise1.then(
-    _result1 => {
+    function(_result1) {
       _hasResult1 = true;
       if (_counter > 0) {
         onResult(
@@ -1225,7 +1225,7 @@ exports[`HookCodeFactory taps (mixed2) callTapsParallel 2`] = `
         );
       }
     },
-    _err1 => {
+    function(_err1) {
       if (_hasResult1) throw _err1;
       if (_counter > 0) {
         onError(1, _err1);
@@ -1276,20 +1276,20 @@ var _hasResult1 = false;
 var _promise1 = _fn1(a, b, c);
 if (!_promise1 || !_promise1.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise1 + ')');
-_promise1.then(_result1 => {
+_promise1.then(function(_result1) {
 _hasResult1 = true;
 onResult(1, _result1, () => {
 _next1();
 }, () => {
 onDone();
 });
-}, _err1 => {
+}, function(_err1) {
 if(_hasResult1) throw _err1;
 onError(1, _err1);
 });
 }
 var _fn0 = _x[0];
-_fn0(a, b, c, (_err0, _result0) => {
+_fn0(a, b, c, function(_err0, _result0) {
 if(_err0) {
 onError(0, _err0);
 } else {
@@ -1337,7 +1337,7 @@ function _next0() {
         \\")\\"
     );
   _promise1.then(
-    _result1 => {
+    function(_result1) {
       _hasResult1 = true;
       onResult(
         1,
@@ -1350,14 +1350,14 @@ function _next0() {
         }
       );
     },
-    _err1 => {
+    function(_err1) {
       if (_hasResult1) throw _err1;
       onError(1, _err1);
     }
   );
 }
 var _fn0 = _x[0];
-_fn0(a, b, c, (_err0, _result0) => {
+_fn0(a, b, c, function(_err0, _result0) {
   if (_err0) {
     onError(0, _err0);
   } else {
@@ -1437,7 +1437,7 @@ do {
 exports[`HookCodeFactory taps (multiple sync) callTapsParallel 1`] = `
 "do {
 var _counter = 3;
-var _done = () => {
+var _done = function() {
 onDone();
 };
 if(_counter <= 0) break;
@@ -1480,7 +1480,7 @@ _done();
 exports[`HookCodeFactory taps (multiple sync) callTapsParallel 2`] = `
 "do {
   var _counter = 3;
-  var _done = () => {
+  var _done = function() {
     onDone();
   };
   if (_counter <= 0) break;
@@ -1627,13 +1627,13 @@ exports[`HookCodeFactory taps (none) callTapsSeries 2`] = `
 `;
 
 exports[`HookCodeFactory taps (single async) callTapsLooping 1`] = `
-"var _looper = () => {
+"var _looper = function() {
 var _loopAsync = false;
 var _loop;
 do {
 _loop = false;
 var _fn0 = _x[0];
-_fn0(a, b, c, (_err0, _result0) => {
+_fn0(a, b, c, function(_err0, _result0) {
 if(_err0) {
 onError(0, _err0);
 } else {
@@ -1655,13 +1655,13 @@ _looper();
 `;
 
 exports[`HookCodeFactory taps (single async) callTapsLooping 2`] = `
-"var _looper = () => {
+"var _looper = function() {
   var _loopAsync = false;
   var _loop;
   do {
     _loop = false;
     var _fn0 = _x[0];
-    _fn0(a, b, c, (_err0, _result0) => {
+    _fn0(a, b, c, function(_err0, _result0) {
       if (_err0) {
         onError(0, _err0);
       } else {
@@ -1684,7 +1684,7 @@ _looper();
 
 exports[`HookCodeFactory taps (single async) callTapsParallel 1`] = `
 "var _fn0 = _x[0];
-_fn0(a, b, c, (_err0, _result0) => {
+_fn0(a, b, c, function(_err0, _result0) {
 if(_err0) {
 onError(0, _err0);
 } else {
@@ -1700,7 +1700,7 @@ onDone();
 
 exports[`HookCodeFactory taps (single async) callTapsParallel 2`] = `
 "var _fn0 = _x[0];
-_fn0(a, b, c, (_err0, _result0) => {
+_fn0(a, b, c, function(_err0, _result0) {
   if (_err0) {
     onError(0, _err0);
   } else {
@@ -1721,7 +1721,7 @@ _fn0(a, b, c, (_err0, _result0) => {
 
 exports[`HookCodeFactory taps (single async) callTapsSeries 1`] = `
 "var _fn0 = _x[0];
-_fn0(a, b, c, (_err0, _result0) => {
+_fn0(a, b, c, function(_err0, _result0) {
 if(_err0) {
 onError(0, _err0);
 } else {
@@ -1737,7 +1737,7 @@ onDone();
 
 exports[`HookCodeFactory taps (single async) callTapsSeries 2`] = `
 "var _fn0 = _x[0];
-_fn0(a, b, c, (_err0, _result0) => {
+_fn0(a, b, c, function(_err0, _result0) {
   if (_err0) {
     onError(0, _err0);
   } else {
@@ -1757,7 +1757,7 @@ _fn0(a, b, c, (_err0, _result0) => {
 `;
 
 exports[`HookCodeFactory taps (single promise) callTapsLooping 1`] = `
-"var _looper = () => {
+"var _looper = function() {
 var _loopAsync = false;
 var _loop;
 do {
@@ -1767,7 +1767,7 @@ var _hasResult0 = false;
 var _promise0 = _fn0(a, b, c);
 if (!_promise0 || !_promise0.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise0 + ')');
-_promise0.then(_result0 => {
+_promise0.then(function(_result0) {
 _hasResult0 = true;
 if(_result0 !== undefined) {
 _loop = true;
@@ -1777,7 +1777,7 @@ if(!_loop) {
 onDone();
 }
 }
-}, _err0 => {
+}, function(_err0) {
 if(_hasResult0) throw _err0;
 onError(0, _err0);
 });
@@ -1789,7 +1789,7 @@ _looper();
 `;
 
 exports[`HookCodeFactory taps (single promise) callTapsLooping 2`] = `
-"var _looper = () => {
+"var _looper = function() {
   var _loopAsync = false;
   var _loop;
   do {
@@ -1804,7 +1804,7 @@ exports[`HookCodeFactory taps (single promise) callTapsLooping 2`] = `
           \\")\\"
       );
     _promise0.then(
-      _result0 => {
+      function(_result0) {
         _hasResult0 = true;
         if (_result0 !== undefined) {
           _loop = true;
@@ -1815,7 +1815,7 @@ exports[`HookCodeFactory taps (single promise) callTapsLooping 2`] = `
           }
         }
       },
-      _err0 => {
+      function(_err0) {
         if (_hasResult0) throw _err0;
         onError(0, _err0);
       }
@@ -1833,14 +1833,14 @@ var _hasResult0 = false;
 var _promise0 = _fn0(a, b, c);
 if (!_promise0 || !_promise0.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise0 + ')');
-_promise0.then(_result0 => {
+_promise0.then(function(_result0) {
 _hasResult0 = true;
 onResult(0, _result0, () => {
 onDone();
 }, () => {
 onDone();
 });
-}, _err0 => {
+}, function(_err0) {
 if(_hasResult0) throw _err0;
 onError(0, _err0);
 });
@@ -1858,7 +1858,7 @@ if (!_promise0 || !_promise0.then)
       \\")\\"
   );
 _promise0.then(
-  _result0 => {
+  function(_result0) {
     _hasResult0 = true;
     onResult(
       0,
@@ -1871,7 +1871,7 @@ _promise0.then(
       }
     );
   },
-  _err0 => {
+  function(_err0) {
     if (_hasResult0) throw _err0;
     onError(0, _err0);
   }
@@ -1885,14 +1885,14 @@ var _hasResult0 = false;
 var _promise0 = _fn0(a, b, c);
 if (!_promise0 || !_promise0.then)
   throw new Error('Tap function (tapPromise) did not return promise (returned ' + _promise0 + ')');
-_promise0.then(_result0 => {
+_promise0.then(function(_result0) {
 _hasResult0 = true;
 onResult(0, _result0, () => {
 onDone();
 }, () => {
 onDone();
 });
-}, _err0 => {
+}, function(_err0) {
 if(_hasResult0) throw _err0;
 onError(0, _err0);
 });
@@ -1910,7 +1910,7 @@ if (!_promise0 || !_promise0.then)
       \\")\\"
   );
 _promise0.then(
-  _result0 => {
+  function(_result0) {
     _hasResult0 = true;
     onResult(
       0,
@@ -1923,7 +1923,7 @@ _promise0.then(
       }
     );
   },
-  _err0 => {
+  function(_err0) {
     if (_hasResult0) throw _err0;
     onError(0, _err0);
   }


### PR DESCRIPTION
First of all, thank you for this great library. I really appreciate all the hard work the WebPack team has done.

I am using this library to create an extendable boilerplate https://www.reactpwa.com, and this library is the core of it. 

I am using tapable on the server-side and client-side as well.

The issue that I am facing with the current setup is, there are arrow functions in the string that is generating code, as a result, the code generated for client-side JavaScript is only usable by browsers that natively support arrow functions (as the string code is not transpiled by Babel). I have converted the arrow functions to ES5 compatible functions and added context `_this` appropriately to the code. 
MAYBE: A better solution would have been integrating a babel transpiler for the string code that is generated, but I am not so sure about that for now.

To,
@sokra or any other maintainer of the project
Can you please check the PR and let me know if this works? or can you please point out the corrections for me to achieve the above?