### PR TITLE
Add test for hook.js

### DIFF
--- a/lib/__tests__/Hook.js
+++ b/lib/__tests__/Hook.js
@@ -72,17 +72,17 @@ describe("Hook", () => {
 
 		const calls = [];
 		hook.tap("A", () => calls.push("A1"));
-		hook.tap("B", () => calls.push("B1"));
 		hook.tap("A", () => calls.push("A2"));
-		hook.tap("B", () => calls.push("B2"));
+		hook.tap("A", () => calls.push("A3"));
+		
 		hook.tap(
 			{
-				name: "C",
-				before: "B"
+				name: "B",
+				before: "A"
 			},
-			() => calls.push("C1")
+			() => calls.push("B1")
 		);
 		hook.call();
-		expect(calls).toEqual(["A1", "B1", "A2", "C1", "B2"]);
+		expect(calls).toEqual(["A1", "A2", "B1", "A3"]);
 	})
 });

--- a/lib/__tests__/Hook.js
+++ b/lib/__tests__/Hook.js
@@ -67,4 +67,22 @@ describe("Hook", () => {
 		hook.call();
 		expect(calls).toEqual(["E", "F", "C", "D", "B", "A"]);
 	});
+	it("should insert hooks right before the latest-added hook of the given hook's name", () => {
+		const hook = new SyncHook();
+
+		const calls = [];
+		hook.tap("A", () => calls.push("A1"));
+		hook.tap("B", () => calls.push("B1"));
+		hook.tap("A", () => calls.push("A2"));
+		hook.tap("B", () => calls.push("B2"));
+		hook.tap(
+			{
+				name: "C",
+				before: "B"
+			},
+			() => calls.push("C1")
+		);
+		hook.call();
+		expect(calls).toEqual(["A1", "B1", "A2", "C1", "B2"]);
+	})
 });


### PR DESCRIPTION
This PR adds a test for Hook.js which describes the current behavior of our tapable lib.

In case we have multiple hooks of the same plugin. For example:

```js
hook.tap("LoggerPlugin", function A);
hook.tap("LoggerPlugin", function B);
hook.tap("LoggerPlugin", function C);
```

Then we want to plug another plugin into before the plugin LoggerPlugin. We write this:

```js
hook.tap({
  name: "WarningLampPlugin",
  before: "LoggerPlugin"
}, function D)
```

Then the execution order we will get is: function A ---> function B ---> function D ---> function C

This behavior is different from my first thought. I thought the execution order would be: D ---> A ---> B ---> C