### PR TITLE
Fix for https://github.com/webpack/tapable/issues/130

### DIFF
--- a/lib/AsyncParallelBailHook.js
+++ b/lib/AsyncParallelBailHook.js
@@ -14,7 +14,7 @@ class AsyncParallelBailHookCodeFactory extends HookCodeFactory {
 		code += "var _checkDone = () => {\n";
 		code += "for(var i = 0; i < _results.length; i++) {\n";
 		code += "var item = _results[i];\n";
-		code += "if(item === undefined) return false;\n";
+		code += "if(item === undefined) continue;\n";
 		code += "if(item.result !== undefined) {\n";
 		code += onResult("item.result");
 		code += "return true;\n";

--- a/lib/HookCodeFactory.js
+++ b/lib/HookCodeFactory.js
@@ -279,13 +279,17 @@ class HookCodeFactory {
 	}) {
 		if (this.options.taps.length === 0) return onDone();
 		const firstAsync = this.options.taps.findIndex(t => t.type !== "sync");
-		const somethingReturns = resultReturns || doneReturns || false;
+		const somethingReturns = resultReturns || doneReturns;
 		let code = "";
 		let current = onDone;
+		let unrollCounter = 0;
 		for (let j = this.options.taps.length - 1; j >= 0; j--) {
 			const i = j;
-			const unroll = current !== onDone && this.options.taps[i].type !== "sync";
+			const unroll =
+				current !== onDone &&
+				(this.options.taps[i].type !== "sync" || unrollCounter++ > 20);
 			if (unroll) {
+				unrollCounter = 0;
 				code += `function _next${i}() {\n`;
 				code += current();
 				code += `}\n`;

--- a/lib/__tests__/AsyncParallelHooks.js
+++ b/lib/__tests__/AsyncParallelHooks.js
@@ -26,4 +26,46 @@ describe("AsyncParallelBailHook", () => {
 
 		expect(result).toMatchSnapshot();
 	}, 15000);
+
+	it("should bail on non-null return", async () => {
+		const h1 = new AsyncParallelBailHook();
+		const mockCall1 = jest.fn();
+		const mockCall2 = jest.fn(() => "B");
+		const mockCall3 = jest.fn(() => "C");
+		h1.tap("A", mockCall1);
+		h1.tap("B", mockCall2);
+		h1.tap("C", mockCall3);
+		expect(await h1.promise()).toEqual("B");
+		expect(mockCall1).toHaveBeenCalledTimes(1);
+		expect(mockCall2).toHaveBeenCalledTimes(1);
+		expect(mockCall3).toHaveBeenCalledTimes(0);
+	}, 15000);
+
+	it("should bail on defined resolution", async () => {
+		// Arrange
+		const mockCall1 = jest.fn(() => undefined);
+		const mockCall2 = jest.fn(() => "B");
+		const mockCall3 = jest.fn(() => "C");
+
+		// Act
+		const h1 = new AsyncParallelBailHook([]);
+		h1.tapPromise(
+			"A",
+			() => new Promise(res => setTimeout(() => res(mockCall1()), 100))
+		);
+		h1.tapPromise(
+			"B",
+			() => new Promise(res => setTimeout(() => res(mockCall2()), 5000))
+		); // <= last to resolve
+		h1.tapPromise(
+			"C",
+			() => new Promise(res => setTimeout(() => res(mockCall3()), 500))
+		);
+
+		// Assert
+		expect(await h1.promise()).toEqual("C");
+		expect(mockCall1).toHaveBeenCalledTimes(1);
+		expect(mockCall2).toHaveBeenCalledTimes(0);
+		expect(mockCall3).toHaveBeenCalledTimes(1);
+	}, 15000);
 });

--- a/lib/__tests__/AsyncSeriesHooks.js
+++ b/lib/__tests__/AsyncSeriesHooks.js
@@ -51,6 +51,16 @@ describe("AsyncSeriesBailHook", () => {
 
 		expect(result).toMatchSnapshot();
 	});
+
+	it("should not crash with many plugins", () => {
+		const hook = new AsyncSeriesBailHook(["x"]);
+		for (let i = 0; i < 1000; i++) {
+			hook.tap("Test", () => 42);
+		}
+		hook.tapAsync("Test", (x, callback) => callback(null, 42));
+		hook.tapPromise("Test", x => Promise.resolve(42));
+		return expect(hook.promise()).resolves.toBe(42);
+	});
 });
 
 describe("AsyncSeriesWaterfallHook", () => {

--- a/lib/__tests__/SyncBailHook.js
+++ b/lib/__tests__/SyncBailHook.js
@@ -82,6 +82,14 @@ describe("SyncBailHook", () => {
 		const hook = new SyncBailHook(["x"]);
 		expect(() => hook.tapPromise()).toThrow(/tapPromise/);
 	});
+
+	it("should not crash with many plugins", () => {
+		const hook = new SyncBailHook(["x"]);
+		for (let i = 0; i < 1000; i++) {
+			hook.tap("Test", () => 42);
+		}
+		expect(hook.call()).toBe(42);
+	});
 });
 
 function pify(fn) {

--- a/lib/__tests__/__snapshots__/AsyncParallelHooks.js.snap
+++ b/lib/__tests__/__snapshots__/AsyncParallelHooks.js.snap
@@ -20,14 +20,14 @@ Object {
     "callAsyncMultipleAsyncLateErrorCalled1": true,
     "callAsyncMultipleAsyncLateErrorCalled3": true,
     "callAsyncMultipleAsyncLateErrorEarlyResult1": Object {
-      "error": "Error in async2",
       "type": "async",
+      "value": 7,
     },
     "callAsyncMultipleAsyncLateErrorEarlyResult1Called1": true,
     "callAsyncMultipleAsyncLateErrorEarlyResult1Called3": true,
     "callAsyncMultipleAsyncLateErrorEarlyResult2": Object {
       "type": "async",
-      "value": 42,
+      "value": 7,
     },
     "callAsyncMultipleAsyncLateErrorEarlyResult2Called1": true,
     "callAsyncMultipleAsyncLateErrorEarlyResult2Called3": true,
@@ -60,7 +60,7 @@ Object {
     "callAsyncMultipleMixed1WithArgCalled1": 42,
     "callAsyncMultipleMixed2WithArg": Object {
       "type": "async",
-      "value": 43,
+      "value": 44,
     },
     "callAsyncMultipleMixed2WithArgCalled1": 42,
     "callAsyncMultipleMixed2WithArgCalled2": 42,
@@ -85,8 +85,8 @@ Object {
     },
     "callAsyncMultipleMixedError3WithArgCalled1": 42,
     "callAsyncMultipleMixedLateError": Object {
-      "error": "Error in async",
       "type": "async",
+      "value": 43,
     },
     "callAsyncMultipleMixedLateErrorCalled1": true,
     "callAsyncMultipleMixedLateErrorCalled2": true,
@@ -227,14 +227,14 @@ Object {
     "promiseMultipleAsyncLateErrorCalled1": true,
     "promiseMultipleAsyncLateErrorCalled3": true,
     "promiseMultipleAsyncLateErrorEarlyResult1": Object {
-      "error": "Error in async2",
       "type": "promise",
+      "value": 7,
     },
     "promiseMultipleAsyncLateErrorEarlyResult1Called1": true,
     "promiseMultipleAsyncLateErrorEarlyResult1Called3": true,
     "promiseMultipleAsyncLateErrorEarlyResult2": Object {
       "type": "promise",
-      "value": 42,
+      "value": 7,
     },
     "promiseMultipleAsyncLateErrorEarlyResult2Called1": true,
     "promiseMultipleAsyncLateErrorEarlyResult2Called3": true,
@@ -267,7 +267,7 @@ Object {
     "promiseMultipleMixed1WithArgCalled1": 42,
     "promiseMultipleMixed2WithArg": Object {
       "type": "promise",
-      "value": 43,
+      "value": 44,
     },
     "promiseMultipleMixed2WithArgCalled1": 42,
     "promiseMultipleMixed2WithArgCalled2": 42,
@@ -292,8 +292,8 @@ Object {
     },
     "promiseMultipleMixedError3WithArgCalled1": 42,
     "promiseMultipleMixedLateError": Object {
-      "error": "Error in async",
       "type": "promise",
+      "value": 43,
     },
     "promiseMultipleMixedLateErrorCalled1": true,
     "promiseMultipleMixedLateErrorCalled2": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapable",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "author": "Tobias Koppers @sokra",
   "description": "Just a little module for plugins.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapable",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "author": "Tobias Koppers @sokra",
   "description": "Just a little module for plugins.",
   "license": "MIT",

--- a/tapable.d.ts
+++ b/tapable.d.ts
@@ -20,7 +20,8 @@ type Append<T extends any[], U> = {
 }[Measure<T["length"]>];
 type AsArray<T> = T extends any[] ? T : [T];
 
-type Callback<E, T> = (error?: E, result?: T) => void;
+type Callback<E, T> = (error: E | null, result?: T) => void;
+type InnerCallback<E, T> = (error?: E | null | false, result?: T) => void;
 
 type Tap = TapOptions & {
 	name: string;
@@ -66,7 +67,7 @@ export class SyncWaterfallHook<T> extends SyncHook<T, AsArray<T>[0]> {}
 declare class AsyncHook<T, R> extends Hook<T, R> {
 	tapAsync(
 		options: string | Tap,
-		fn: (...args: Append<AsArray<T>, Callback<Error, R>>) => void
+		fn: (...args: Append<AsArray<T>, InnerCallback<Error, R>>) => void
 	): void;
 	tapPromise(
 		options: string | Tap,


### PR DESCRIPTION
This mr provides a possible fix for unexpected behavior of `AsyncParallelBailHook`.

According to the documentation, bail hooks stop executing as soon as one of the tapped function produces a defined value. 