### PR TITLE
Fix for https://github.com/webpack/tapable/issues/130

### DIFF
--- a/lib/AsyncParallelBailHook.js
+++ b/lib/AsyncParallelBailHook.js
@@ -14,7 +14,7 @@ class AsyncParallelBailHookCodeFactory extends HookCodeFactory {
 		code += "var _checkDone = () => {\n";
 		code += "for(var i = 0; i < _results.length; i++) {\n";
 		code += "var item = _results[i];\n";
-		code += "if(item === undefined) return false;\n";
+		code += "if(item === undefined) continue;\n";
 		code += "if(item.result !== undefined) {\n";
 		code += onResult("item.result");
 		code += "return true;\n";

--- a/lib/__tests__/AsyncParallelHooks.js
+++ b/lib/__tests__/AsyncParallelHooks.js
@@ -26,4 +26,46 @@ describe("AsyncParallelBailHook", () => {
 
 		expect(result).toMatchSnapshot();
 	}, 15000);
+
+	it("should bail on non-null return", async () => {
+		const h1 = new AsyncParallelBailHook();
+		const mockCall1 = jest.fn();
+		const mockCall2 = jest.fn(() => "B");
+		const mockCall3 = jest.fn(() => "C");
+		h1.tap("A", mockCall1);
+		h1.tap("B", mockCall2);
+		h1.tap("C", mockCall3);
+		expect(await h1.promise()).toEqual("B");
+		expect(mockCall1).toHaveBeenCalledTimes(1);
+		expect(mockCall2).toHaveBeenCalledTimes(1);
+		expect(mockCall3).toHaveBeenCalledTimes(0);
+	}, 15000);
+
+	it("should bail on defined resolution", async () => {
+		// Arrange
+		const mockCall1 = jest.fn(() => undefined);
+		const mockCall2 = jest.fn(() => "B");
+		const mockCall3 = jest.fn(() => "C");
+
+		// Act
+		const h1 = new AsyncParallelBailHook([]);
+		h1.tapPromise(
+			"A",
+			() => new Promise(res => setTimeout(() => res(mockCall1()), 100))
+		);
+		h1.tapPromise(
+			"B",
+			() => new Promise(res => setTimeout(() => res(mockCall2()), 5000))
+		); // <= last to resolve
+		h1.tapPromise(
+			"C",
+			() => new Promise(res => setTimeout(() => res(mockCall3()), 500))
+		);
+
+		// Assert
+		expect(await h1.promise()).toEqual("C");
+		expect(mockCall1).toHaveBeenCalledTimes(1);
+		expect(mockCall2).toHaveBeenCalledTimes(0);
+		expect(mockCall3).toHaveBeenCalledTimes(1);
+	}, 15000);
 });

--- a/lib/__tests__/__snapshots__/AsyncParallelHooks.js.snap
+++ b/lib/__tests__/__snapshots__/AsyncParallelHooks.js.snap
@@ -20,14 +20,14 @@ Object {
     "callAsyncMultipleAsyncLateErrorCalled1": true,
     "callAsyncMultipleAsyncLateErrorCalled3": true,
     "callAsyncMultipleAsyncLateErrorEarlyResult1": Object {
-      "error": "Error in async2",
       "type": "async",
+      "value": 7,
     },
     "callAsyncMultipleAsyncLateErrorEarlyResult1Called1": true,
     "callAsyncMultipleAsyncLateErrorEarlyResult1Called3": true,
     "callAsyncMultipleAsyncLateErrorEarlyResult2": Object {
       "type": "async",
-      "value": 42,
+      "value": 7,
     },
     "callAsyncMultipleAsyncLateErrorEarlyResult2Called1": true,
     "callAsyncMultipleAsyncLateErrorEarlyResult2Called3": true,
@@ -60,7 +60,7 @@ Object {
     "callAsyncMultipleMixed1WithArgCalled1": 42,
     "callAsyncMultipleMixed2WithArg": Object {
       "type": "async",
-      "value": 43,
+      "value": 44,
     },
     "callAsyncMultipleMixed2WithArgCalled1": 42,
     "callAsyncMultipleMixed2WithArgCalled2": 42,
@@ -85,8 +85,8 @@ Object {
     },
     "callAsyncMultipleMixedError3WithArgCalled1": 42,
     "callAsyncMultipleMixedLateError": Object {
-      "error": "Error in async",
       "type": "async",
+      "value": 43,
     },
     "callAsyncMultipleMixedLateErrorCalled1": true,
     "callAsyncMultipleMixedLateErrorCalled2": true,
@@ -227,14 +227,14 @@ Object {
     "promiseMultipleAsyncLateErrorCalled1": true,
     "promiseMultipleAsyncLateErrorCalled3": true,
     "promiseMultipleAsyncLateErrorEarlyResult1": Object {
-      "error": "Error in async2",
       "type": "promise",
+      "value": 7,
     },
     "promiseMultipleAsyncLateErrorEarlyResult1Called1": true,
     "promiseMultipleAsyncLateErrorEarlyResult1Called3": true,
     "promiseMultipleAsyncLateErrorEarlyResult2": Object {
       "type": "promise",
-      "value": 42,
+      "value": 7,
     },
     "promiseMultipleAsyncLateErrorEarlyResult2Called1": true,
     "promiseMultipleAsyncLateErrorEarlyResult2Called3": true,
@@ -267,7 +267,7 @@ Object {
     "promiseMultipleMixed1WithArgCalled1": 42,
     "promiseMultipleMixed2WithArg": Object {
       "type": "promise",
-      "value": 43,
+      "value": 44,
     },
     "promiseMultipleMixed2WithArgCalled1": 42,
     "promiseMultipleMixed2WithArgCalled2": 42,
@@ -292,8 +292,8 @@ Object {
     },
     "promiseMultipleMixedError3WithArgCalled1": 42,
     "promiseMultipleMixedLateError": Object {
-      "error": "Error in async",
       "type": "promise",
+      "value": 43,
     },
     "promiseMultipleMixedLateErrorCalled1": true,
     "promiseMultipleMixedLateErrorCalled2": true,


### PR DESCRIPTION
This mr provides a possible fix for [unexpected behavior](https://github.com/webpack/tapable/issues/130) of `AsyncParallelBailHook`.

According to the documentation, bail hooks stop executing as soon as one of the tapped function produces a defined value. 