### PR TITLE
trim name option

### DIFF
--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -58,7 +58,7 @@ class Hook {
 	_tap(type, options, fn) {
 		if (typeof options === "string") {
 			options = {
-				name: options
+				name: options.trim()
 			};
 		} else if (typeof options !== "object" || options === null) {
 			throw new Error("Invalid tap options");

--- a/lib/__tests__/Hook.js
+++ b/lib/__tests__/Hook.js
@@ -67,4 +67,13 @@ describe("Hook", () => {
 		hook.call();
 		expect(calls).toEqual(["E", "F", "C", "D", "B", "A"]);
 	});
+	it("should throw without a valid name", () => {
+		const hook = new SyncHook();
+		expect(() => hook.tap("", () => {})).toThrow(
+			new Error("Missing name for tap")
+		);
+		expect(() => hook.tap(" ", () => {})).toThrow(
+			new Error("Missing name for tap")
+		);
+	});
 });


### PR DESCRIPTION
I think `name` of `" "` should throw too.