### PR TITLE
Remove usage of node internal/util to support bundling with webpack 5 with no need of node polyfills 

### DIFF
--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -4,9 +4,9 @@
 */
 "use strict";
 
-const util = require("util");
+const util = require("./Util");
 
-const deprecateContext = util.deprecate(() => {},
+const deprecateContext = util.deprecateMethod(() => {},
 "Hook.context is deprecated and will be removed");
 
 const CALL_DELEGATE = function(...args) {

--- a/lib/HookMap.js
+++ b/lib/HookMap.js
@@ -4,7 +4,7 @@
 */
 "use strict";
 
-const util = require("util");
+const util = require("./Util");
 
 const defaultFactory = (key, hook) => hook;
 
@@ -46,15 +46,15 @@ class HookMap {
 	}
 }
 
-HookMap.prototype.tap = util.deprecate(function(key, options, fn) {
+HookMap.prototype.tap = util.deprecateMethod(function(key, options, fn) {
 	return this.for(key).tap(options, fn);
 }, "HookMap#tap(key,…) is deprecated. Use HookMap#for(key).tap(…) instead.");
 
-HookMap.prototype.tapAsync = util.deprecate(function(key, options, fn) {
+HookMap.prototype.tapAsync = util.deprecateMethod(function(key, options, fn) {
 	return this.for(key).tapAsync(options, fn);
 }, "HookMap#tapAsync(key,…) is deprecated. Use HookMap#for(key).tapAsync(…) instead.");
 
-HookMap.prototype.tapPromise = util.deprecate(function(key, options, fn) {
+HookMap.prototype.tapPromise = util.deprecateMethod(function(key, options, fn) {
 	return this.for(key).tapPromise(options, fn);
 }, "HookMap#tapPromise(key,…) is deprecated. Use HookMap#for(key).tapPromise(…) instead.");
 

--- a/lib/Util.js
+++ b/lib/Util.js
@@ -1,0 +1,22 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+function deprecateMethod(fn, msg) {
+	let warned = false;
+	return function deprecated(...args) {
+		if (!warned) {
+			warned = true;
+			if (typeof process === "undefined") {
+				console.warn("DeprecationWarning:", msg);
+			} else {
+				process.emitWarning(msg, "DeprecationWarning", deprecated);
+			}
+		}
+		return fn.apply(this, args);
+	}
+}
+
+module.exports.deprecateMethod = deprecateMethod;


### PR DESCRIPTION
tapable should be able to work in browser. 
The usage of nodes `internal/util`  is the only thing that stops it from bundle without any node polyfills.

I notice that the usage of the `util.deprecate` function is limited to methods, so I created a simple universal `deprecateMethod` function that works both in browser and node.

In node it still uses `process.emitWarning` and in browser `console.warn`.