### PR TITLE
fix: set withOptions return type to include correct properties

### DIFF
--- a/tapable.d.ts
+++ b/tapable.d.ts
@@ -63,7 +63,7 @@ declare class Hook<T, R, AdditionalOptions = UnsetAdditionalOptions> {
 	callAsync(...args: Append<AsArray<T>, Callback<Error, R>>): void;
 	promise(...args: AsArray<T>): Promise<R>;
 	tap(options: string | Tap & IfSet<AdditionalOptions>, fn: (...args: AsArray<T>) => R): void;
-	withOptions(options: TapOptions & IfSet<AdditionalOptions>): Hook<T, R>;
+	withOptions(options: TapOptions & IfSet<AdditionalOptions>): Omit<this, 'call' | 'callAsync'>;
 }
 
 export class SyncHook<T, R = void, AdditionalOptions = UnsetAdditionalOptions> extends Hook<T, R, AdditionalOptions> {

--- a/tapable.d.ts
+++ b/tapable.d.ts
@@ -63,7 +63,7 @@ declare class Hook<T, R, AdditionalOptions = UnsetAdditionalOptions> {
 	callAsync(...args: Append<AsArray<T>, Callback<Error, R>>): void;
 	promise(...args: AsArray<T>): Promise<R>;
 	tap(options: string | Tap & IfSet<AdditionalOptions>, fn: (...args: AsArray<T>) => R): void;
-	withOptions(options: TapOptions & IfSet<AdditionalOptions>): Omit<this, 'call' | 'callAsync'>;
+	withOptions(options: TapOptions & IfSet<AdditionalOptions>): Omit<this, "call" | "callAsync" | "promise">;
 }
 
 export class SyncHook<T, R = void, AdditionalOptions = UnsetAdditionalOptions> extends Hook<T, R, AdditionalOptions> {


### PR DESCRIPTION
Current behavior:

withOptions return type
- does contain callAsync, which doesn't exist
- doesn't contain tapAsync or tapPromise, which does exist

Expected behavior:

withOptions return type
- should be limited to return value in source
- should include properties depends on the current child instance

related withOptions source code: https://github.com/webpack/tapable/blob/413fa785018406464963c29d172e06d2df42f22e/lib/Hook.js#L105