### PR TITLE
add taps type to hook class

### DIFF
--- a/tapable.d.ts
+++ b/tapable.d.ts
@@ -58,6 +58,7 @@ type ArgumentNames<T extends any[]> = FixedSizeArray<T["length"], string>;
 declare class Hook<T, R, AdditionalOptions = UnsetAdditionalOptions> {
 	constructor(args?: ArgumentNames<AsArray<T>>, name?: string);
 	name: string | undefined;
+	taps: FullTap[];
 	intercept(interceptor: HookInterceptor<T, R, AdditionalOptions>): void;
 	isUsed(): boolean;
 	callAsync(...args: Append<AsArray<T>, Callback<Error, R>>): void;


### PR DESCRIPTION
### Summary

Add taps type to hook class, make the following code works

```
const appliedPluginNames: Set<string> = new Set<string>(pluginHook.taps.map(x => x.name));
```

which also fixes https://github.com/webpack/tapable/issues/152