### PR TITLE
Add context support for Hook TS types

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "scripts": {
     "test": "jest",
     "travis": "yarn pretty-lint && jest --coverage && codecov",
-    "pretty-lint": "prettier --check lib/*.js lib/__tests__/*.js",
-    "pretty": "prettier --loglevel warn --write lib/*.js lib/__tests__/*.js"
+    "pretty-lint": "prettier --check lib/*.js lib/__tests__/*.js tapable.d.ts",
+    "pretty": "prettier --loglevel warn --write lib/*.js lib/__tests__/*.js tapable.d.ts"
   },
   "jest": {
     "transform": {

--- a/tapable.d.ts
+++ b/tapable.d.ts
@@ -21,7 +21,7 @@ type Append<T extends any[], U> = {
 type AsArray<T> = T extends any[] ? T : [T];
 
 declare class UnsetAdditionalOptions {
-	_UnsetAdditionalOptions: true
+	_UnsetAdditionalOptions: true;
 }
 type IfSet<X> = X extends UnsetAdditionalOptions ? {} : X;
 
@@ -29,9 +29,9 @@ type Callback<E, T> = (error: E | null, result?: T) => void;
 type InnerCallback<E, T> = (error?: E | null | false, result?: T) => void;
 
 type FullTap = Tap & {
-	type: "sync" | "async" | "promise",
-	fn: Function
-}
+	type: "sync" | "async" | "promise";
+	fn: Function;
+};
 
 type Tap = TapOptions & {
 	name: string;
@@ -42,40 +42,110 @@ type TapOptions = {
 	stage?: number;
 };
 
-interface HookInterceptor<T, R, AdditionalOptions = UnsetAdditionalOptions> {
+type HookInterceptor<
+	T,
+	R,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> =
+	| HookInterceptorWithContext<T, R, AdditionalOptions, ContextType>
+	| HookInterceptorWithoutContext<T, R, AdditionalOptions>;
+
+interface HookInterceptorWithContext<
+	T,
+	R,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> {
 	name?: string;
-	tap?: (tap: FullTap & IfSet<AdditionalOptions>) => void;
-	call?: (...args: any[]) => void;
-	loop?: (...args: any[]) => void;
+	context: true;
+	tap?: (context: ContextType, tap: FullTap & IfSet<AdditionalOptions>) => void;
+	call?: (context: ContextType, ...args: AsArray<T>) => void;
+	loop?: (context: ContextType, ...args: AsArray<T>) => void;
 	error?: (err: Error) => void;
 	result?: (result: R) => void;
 	done?: () => void;
-	register?: (tap: FullTap & IfSet<AdditionalOptions>) => FullTap & IfSet<AdditionalOptions>;
+	register?: (
+		tap: FullTap & IfSet<AdditionalOptions>
+	) => FullTap & IfSet<AdditionalOptions>;
+}
+
+interface HookInterceptorWithoutContext<
+	T,
+	R,
+	AdditionalOptions = UnsetAdditionalOptions
+> {
+	name?: string;
+	context?: false;
+	tap?: (tap: FullTap & IfSet<AdditionalOptions>) => void;
+	call?: (...args: AsArray<T>) => void;
+	loop?: (...args: AsArray<T>) => void;
+	error?: (err: Error) => void;
+	result?: (result: R) => void;
+	done?: () => void;
+	register?: (
+		tap: FullTap & IfSet<AdditionalOptions>
+	) => FullTap & IfSet<AdditionalOptions>;
 }
 
 type ArgumentNames<T extends any[]> = FixedSizeArray<T["length"], string>;
 
-declare class Hook<T, R, AdditionalOptions = UnsetAdditionalOptions> {
+declare class Hook<
+	T,
+	R,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> {
 	constructor(args?: ArgumentNames<AsArray<T>>, name?: string);
 	name: string | undefined;
 	taps: FullTap[];
-	intercept(interceptor: HookInterceptor<T, R, AdditionalOptions>): void;
+	intercept(
+		interceptor: HookInterceptor<T, R, AdditionalOptions, ContextType>
+	): void;
 	isUsed(): boolean;
 	callAsync(...args: Append<AsArray<T>, Callback<Error, R>>): void;
 	promise(...args: AsArray<T>): Promise<R>;
-	tap(options: string | Tap & IfSet<AdditionalOptions>, fn: (...args: AsArray<T>) => R): void;
-	withOptions(options: TapOptions & IfSet<AdditionalOptions>): Omit<this, "call" | "callAsync" | "promise">;
+	tap(
+		options: string | Tap & IfSet<AdditionalOptions>,
+		fn: (...args: AsArray<T>) => R
+	): void;
+	withOptions(
+		options: TapOptions & IfSet<AdditionalOptions>
+	): Omit<this, "call" | "callAsync" | "promise">;
 }
 
-export class SyncHook<T, R = void, AdditionalOptions = UnsetAdditionalOptions> extends Hook<T, R, AdditionalOptions> {
+export class SyncHook<
+	T,
+	R = void,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends Hook<T, R, AdditionalOptions, ContextType> {
 	call(...args: AsArray<T>): R;
 }
 
-export class SyncBailHook<T, R, AdditionalOptions = UnsetAdditionalOptions> extends SyncHook<T, R, AdditionalOptions> {}
-export class SyncLoopHook<T, AdditionalOptions = UnsetAdditionalOptions> extends SyncHook<T, void, AdditionalOptions> {}
-export class SyncWaterfallHook<T, AdditionalOptions = UnsetAdditionalOptions> extends SyncHook<T, AsArray<T>[0], AdditionalOptions> {}
+export class SyncBailHook<
+	T,
+	R,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends SyncHook<T, R, AdditionalOptions, ContextType> {}
+export class SyncLoopHook<
+	T,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends SyncHook<T, void, AdditionalOptions, ContextType> {}
+export class SyncWaterfallHook<
+	T,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends SyncHook<T, AsArray<T>[0], AdditionalOptions, ContextType> {}
 
-declare class AsyncHook<T, R, AdditionalOptions = UnsetAdditionalOptions> extends Hook<T, R, AdditionalOptions> {
+declare class AsyncHook<
+	T,
+	R,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends Hook<T, R, AdditionalOptions, ContextType> {
 	tapAsync(
 		options: string | Tap & IfSet<AdditionalOptions>,
 		fn: (...args: Append<AsArray<T>, InnerCallback<Error, R>>) => void
@@ -86,12 +156,38 @@ declare class AsyncHook<T, R, AdditionalOptions = UnsetAdditionalOptions> extend
 	): void;
 }
 
-export class AsyncParallelHook<T, AdditionalOptions = UnsetAdditionalOptions> extends AsyncHook<T, void, AdditionalOptions> {}
-export class AsyncParallelBailHook<T, R, AdditionalOptions = UnsetAdditionalOptions> extends AsyncHook<T, R, AdditionalOptions> {}
-export class AsyncSeriesHook<T, AdditionalOptions = UnsetAdditionalOptions> extends AsyncHook<T, void, AdditionalOptions> {}
-export class AsyncSeriesBailHook<T, R, AdditionalOptions = UnsetAdditionalOptions> extends AsyncHook<T, R, AdditionalOptions> {}
-export class AsyncSeriesLoopHook<T, AdditionalOptions = UnsetAdditionalOptions> extends AsyncHook<T, void, AdditionalOptions> {}
-export class AsyncSeriesWaterfallHook<T, AdditionalOptions = UnsetAdditionalOptions> extends AsyncHook<T, AsArray<T>[0], AdditionalOptions> {}
+export class AsyncParallelHook<
+	T,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends AsyncHook<T, void, AdditionalOptions, ContextType> {}
+export class AsyncParallelBailHook<
+	T,
+	R,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends AsyncHook<T, R, AdditionalOptions, ContextType> {}
+export class AsyncSeriesHook<
+	T,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends AsyncHook<T, void, AdditionalOptions, ContextType> {}
+export class AsyncSeriesBailHook<
+	T,
+	R,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends AsyncHook<T, R, AdditionalOptions, ContextType> {}
+export class AsyncSeriesLoopHook<
+	T,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends AsyncHook<T, void, AdditionalOptions, ContextType> {}
+export class AsyncSeriesWaterfallHook<
+	T,
+	AdditionalOptions = UnsetAdditionalOptions,
+	ContextType = unknown
+> extends AsyncHook<T, AsArray<T>[0], AdditionalOptions, ContextType> {}
 
 type HookFactory<H> = (key: any, hook?: H) => H;
 


### PR DESCRIPTION
TL;DR

* Adds `context` support for the Hook interface 
* Ran `prettier` and adds `tapable.d.ts` to the list of files to format

--

Happy to split this PR up into 2 if that makes it easier to review.

The main change was the addition of another parameter to the base `Hook` interface for `Context`, that's then passed down to the `HookInterceptor` type, which is now a discriminated union based on the presence of the `context: true` parameter to the `intercept()` call and augments the expected arguments. 

I also updated the args in `call()` and `loop()` to leverage the argument types in their signature (instead of `any[]`) 


Fixes #171 