### PR TITLE
fix: add es6 support in eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
 	"env": {
-		"node": true
+		"node": true,
+		"es6": true
 	},
 	"rules": {
 		"strict": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
 	"env": {
 		"node": true,
-		"es6": true
+		"es2021": true
 	},
 	"rules": {
 		"strict": 0,


### PR DESCRIPTION
Fix the error `Parsing error: The keyword 'const' is reserved` generated in IDEs due to the default ES5 syntax-checking of ESLint.