### PR TITLE
fix HookMap description

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ myCar.hooks.accelerate.tap({
 A HookMap is a helper class for a Map with Hooks
 
 ``` js
-const keyedHook = new HookMap(key => new SyncHook(["arg"]))
+const keyedHook = new HookMap(key => new AsyncSeriesHook(["arg"]))
 ```
 
 ``` js


### PR DESCRIPTION
A sync hook can only be tapped with synchronous functions. So if the HookMap want to  use `tapAsync` or `tapPromise` methods, it should use async hooks,  such as `AsyncSeriesHook`.


![image](https://user-images.githubusercontent.com/37829041/198823582-ede55139-2c21-48d6-bd17-5b85255fcde4.png)

