### PR TITLE
fix: support pass return type for waterfall hooks

### DIFF
--- a/lib/__tests__/AsyncSeriesHooks.js
+++ b/lib/__tests__/AsyncSeriesHooks.js
@@ -100,6 +100,13 @@ describe("AsyncSeriesWaterfallHook", () => {
 		hook.tap("undefined", () => null);
 		return expect(hook.promise()).resolves.toBeNull();
 	});
+
+	it("should work with different types", async () => {
+		const hook = new AsyncSeriesWaterfallHook(["x"]);
+		hook.tap("number", () => 42);
+		hook.tap("string", () => "string");
+		return expect(hook.promise()).resolves.toBe("string");
+	});
 });
 
 describe("AsyncSeriesLoopHook", () => {

--- a/lib/__tests__/SyncWaterfallHook.js
+++ b/lib/__tests__/SyncWaterfallHook.js
@@ -59,6 +59,13 @@ describe("SyncWaterfallHook", () => {
 		return expect(hook.call()).toBeNull();
 	});
 
+	it("should work with different types", async () => {
+		const hook = new SyncWaterfallHook(["x"]);
+		hook.tap("number", () => 42);
+		hook.tap("string", () => "string");
+		return expect(hook.call()).toBe("string");
+	});
+
 	it("should allow to create sync hooks", async () => {
 		const hook = new SyncWaterfallHook(["arg1", "arg2"]);
 

--- a/tapable.d.ts
+++ b/tapable.d.ts
@@ -94,8 +94,9 @@ export class SyncLoopHook<
 > extends SyncHook<T, void, AdditionalOptions> {}
 export class SyncWaterfallHook<
 	T,
+	R = AsArray<T>[0],
 	AdditionalOptions = UnsetAdditionalOptions
-> extends SyncHook<T, AsArray<T>[0] | void, AdditionalOptions> {}
+> extends SyncHook<T, R, AdditionalOptions> {}
 
 declare class AsyncHook<
 	T,
@@ -136,8 +137,9 @@ export class AsyncSeriesLoopHook<
 > extends AsyncHook<T, void, AdditionalOptions> {}
 export class AsyncSeriesWaterfallHook<
 	T,
+	R = AsArray<T>[0],
 	AdditionalOptions = UnsetAdditionalOptions
-> extends AsyncHook<T, AsArray<T>[0] | void, AdditionalOptions> {}
+> extends AsyncHook<T, R, AdditionalOptions> {}
 
 type HookFactory<H> = (key: any, hook?: H) => H;
 


### PR DESCRIPTION
fixes https://github.com/webpack/tapable/pull/165