### PR TITLE
Ignore invalid before values

### DIFF
--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -152,6 +152,13 @@ class Hook {
 		} else if (Array.isArray(item.before)) {
 			before = new Set(item.before);
 		}
+		if (before) {
+			for (const name of before) {
+				if (!this.taps.some((tap) => tap.name === name)) {
+					before.delete(name);
+				}
+			}
+		}
 		let stage = 0;
 		if (typeof item.stage === "number") {
 			stage = item.stage;

--- a/lib/__tests__/Hook.js
+++ b/lib/__tests__/Hook.js
@@ -107,4 +107,48 @@ describe("Hook", () => {
 			new Error("Missing name for tap")
 		);
 	});
+
+	it("should ignore invalid before values", () => {
+		const hook = new SyncHook();
+
+		const calls = [];
+
+		hook.tap("A", () => calls.push("A"));
+
+		hook.tap(
+			{
+				name: "B",
+				before: "C"
+			},
+			() => calls.push("B")
+		);
+
+		hook.tap(
+			{
+				name: "C",
+				before: [" "]
+			},
+			() => calls.push("C")
+		);
+
+		hook.tap(
+			{
+				name: "D",
+				before: {}
+			},
+			() => calls.push("D")
+		);
+
+		hook.tap(
+			{
+				name: "E",
+				before: null
+			},
+			() => calls.push("E")
+		);
+
+		calls.length = 0;
+		hook.call();
+		expect(calls).toEqual(["A", "B", "C", "D", "E"]);
+	});
 });


### PR DESCRIPTION
In the current `_insert` implementation, invalid `before` values (e.g., objects or `null`) are ignored.

However, when `before` is a string (or array of strings) referencing names that do **not** exist in the current taps, the tap is inserted at the very beginning. This behavior seems unintended.

For example:

```js
const hook = new SyncHook();

hook.tap("A", () => {
  console.log("A");
});

hook.tap(
  {
    name: "B",
    before: "C"
  },
  () => {
    console.log("B");
  }
);

hook.tap(
  {
    name: "C",
    before: [" "]  // invalid name
  },
  () => {
    console.log("C");
  }
);

// Current output: C B A
// Expected: A B C
hook.call();