### PR TITLE
MultiHook should support different types of hooks

### DIFF
--- a/lib/MultiHook.js
+++ b/lib/MultiHook.js
@@ -12,38 +12,40 @@ class MultiHook {
 
 	tap(options, fn) {
 		for (const hook of this.hooks) {
-			hook.tap(options, fn);
+			if (hook.tap) hook.tap(options, fn);
 		}
 	}
 
 	tapAsync(options, fn) {
 		for (const hook of this.hooks) {
-			hook.tapAsync(options, fn);
+			if (hook.tapAsync) hook.tapAsync(options, fn);
 		}
 	}
 
 	tapPromise(options, fn) {
 		for (const hook of this.hooks) {
-			hook.tapPromise(options, fn);
+			if (hook.tapPromise) hook.tapPromise(options, fn);
 		}
 	}
 
 	isUsed() {
 		for (const hook of this.hooks) {
-			if (hook.isUsed()) return true;
+			if (hook.isUsed && hook.isUsed()) return true;
 		}
 		return false;
 	}
 
 	intercept(interceptor) {
 		for (const hook of this.hooks) {
-			hook.intercept(interceptor);
+			if (hook.intercept) hook.intercept(interceptor);
 		}
 	}
 
 	withOptions(options) {
 		return new MultiHook(
-			this.hooks.map((hook) => hook.withOptions(options)),
+			this.hooks.map((hook) =>
+				hook.withOptions ? hook.withOptions(options) : hook
+			),
 			this.name
 		);
 	}

--- a/lib/__tests__/MultiHook.js
+++ b/lib/__tests__/MultiHook.js
@@ -69,4 +69,27 @@ describe("MultiHook", () => {
 		expect(new MultiHook([fakeHook2, fakeHook1]).isUsed()).toBe(true);
 		expect(new MultiHook([fakeHook2, fakeHook2]).isUsed()).toBe(false);
 	});
+
+	it("should support different types of hooks", () => {
+		const calls = [];
+		const fakeHook1 = {
+			tap: (options, fn) => {
+				calls.push({ options, fn });
+			}
+		};
+		const fakeHook2 = {
+			tapPromise: (options, fn) => {
+				calls.push({ options, fn });
+			}
+		};
+		const hook = new MultiHook([fakeHook1, fakeHook1, fakeHook2, fakeHook2]);
+		hook.tap("options", "fn1");
+		hook.tapPromise("options", "fn2");
+		expect(calls).toEqual([
+			{ options: "options", fn: "fn1" },
+			{ options: "options", fn: "fn1" },
+			{ options: "options", fn: "fn2" },
+			{ options: "options", fn: "fn2" }
+		]);
+	});
 });


### PR DESCRIPTION
In the current implementation of MultiHook, there is no check for whether a method exists on each hook before invoking it, I think this maybe lead to issues.

For example:
```js
const hook = new MultiHook([new SyncHook(), new AsyncSeriesHook()]);

hook.tap("A", () => {
  console.log("A");
});  // This works on both hooks

hook.tapPromise("B", () => {
  console.log("B");
});  // This will throw because SyncHook does not have tapPromise
```

I think a better approach would be to skip the call on any hook that does not support the method, rather than throwing an error.